### PR TITLE
Make @Throws getter functions properties

### DIFF
--- a/couchbase-lite-ee/src/appleMain/ee/kotbase/MessageEndpointListenerConfiguration.apple.kt
+++ b/couchbase-lite-ee/src/appleMain/ee/kotbase/MessageEndpointListenerConfiguration.apple.kt
@@ -28,7 +28,7 @@ internal constructor(
 
     @Deprecated(
         "Use MessageEndpointListener(Collection, ProtocolType)",
-        ReplaceWith("MessageEndpointListener(setOf(database.getDefaultCollection()!!), protocolType)")
+        ReplaceWith("MessageEndpointListener(setOf(database.defaultCollection), protocolType)")
     )
     public actual constructor(
         database: Database,
@@ -36,7 +36,7 @@ internal constructor(
     ) : this(
         CBLMessageEndpointListenerConfiguration(database.actual, protocolType.actual),
         database,
-        setOf(database.getDefaultCollection())
+        setOf(database.defaultCollection)
     )
 
     public actual constructor(collections: Set<Collection>, protocolType: ProtocolType) : this(

--- a/couchbase-lite-ee/src/appleMain/ee/kotbase/URLEndpointListenerConfiguration.apple.kt
+++ b/couchbase-lite-ee/src/appleMain/ee/kotbase/URLEndpointListenerConfiguration.apple.kt
@@ -32,7 +32,7 @@ private constructor(
 
     @Deprecated(
         "Use URLEndpointListenerConfiguration(Collections)",
-        ReplaceWith("URLEndpointListenerConfiguration(setOf(database.getDefaultCollection()!!), networkInterface, port, disableTls, identity, authenticator, readOnly, enableDeltaSync)")
+        ReplaceWith("URLEndpointListenerConfiguration(setOf(database.defaultCollection), networkInterface, port, disableTls, identity, authenticator, readOnly, enableDeltaSync)")
     )
     public actual constructor(
         database: Database,
@@ -45,7 +45,7 @@ private constructor(
         enableDeltaSync: Boolean
     ) : this(
         database,
-        setOf(database.getDefaultCollection()),
+        setOf(database.defaultCollection),
         identity,
         authenticator,
         CBLURLEndpointListenerConfiguration(database.actual).apply {

--- a/couchbase-lite-ee/src/commonMain/ee/kotbase/MessageEndpointListenerConfiguration.kt
+++ b/couchbase-lite-ee/src/commonMain/ee/kotbase/MessageEndpointListenerConfiguration.kt
@@ -30,7 +30,7 @@ public expect class MessageEndpointListenerConfiguration {
      */
     @Deprecated(
         "Use MessageEndpointListener(Collection, ProtocolType)",
-        ReplaceWith("MessageEndpointListener(setOf(database.getDefaultCollection()!!), protocolType)")
+        ReplaceWith("MessageEndpointListener(setOf(database.defaultCollection), protocolType)")
     )
     public constructor(database: Database, protocolType: ProtocolType)
 

--- a/couchbase-lite-ee/src/commonMain/ee/kotbase/URLEndpointListenerConfiguration.kt
+++ b/couchbase-lite-ee/src/commonMain/ee/kotbase/URLEndpointListenerConfiguration.kt
@@ -30,7 +30,7 @@ public expect class URLEndpointListenerConfiguration {
      */
     @Deprecated(
         "Use URLEndpointListenerConfiguration(Collections)",
-        ReplaceWith("URLEndpointListenerConfiguration(setOf(database.getDefaultCollection()!!), networkInterface, port, disableTls, identity, authenticator, readOnly, enableDeltaSync)")
+        ReplaceWith("URLEndpointListenerConfiguration(setOf(database.defaultCollection), networkInterface, port, disableTls, identity, authenticator, readOnly, enableDeltaSync)")
     )
     public constructor(
         database: Database,

--- a/couchbase-lite-ee/src/commonTest/ee/kotbase/DatabaseEncryptionTest.kt
+++ b/couchbase-lite-ee/src/commonTest/ee/kotbase/DatabaseEncryptionTest.kt
@@ -41,7 +41,7 @@ class DatabaseEncryptionTest : BaseDbTest() {
         seekrit = openSeekrit(null)
 
         val doc = MutableDocument(mapOf("answer" to 42))
-        seekrit!!.getDefaultCollection()!!.save(doc)
+        seekrit!!.defaultCollection.save(doc)
         seekrit!!.close()
         seekrit = null
 
@@ -52,7 +52,7 @@ class DatabaseEncryptionTest : BaseDbTest() {
 
         // Reopen with no password:
         seekrit = openSeekrit(null)
-        assertEquals(1, seekrit!!.getDefaultCollection()!!.count)
+        assertEquals(1, seekrit!!.defaultCollection.count)
     }
 
     @Test
@@ -61,7 +61,7 @@ class DatabaseEncryptionTest : BaseDbTest() {
         seekrit = openSeekrit("letmein")
 
         val doc = MutableDocument(mapOf("answer" to 42))
-        seekrit!!.getDefaultCollection()!!.save(doc)
+        seekrit!!.defaultCollection.save(doc)
         seekrit!!.close()
         seekrit = null
 
@@ -89,12 +89,12 @@ class DatabaseEncryptionTest : BaseDbTest() {
 
         // Re-create database:
         seekrit = openSeekrit(null)
-        assertEquals(0, seekrit!!.getDefaultCollection()!!.count)
+        assertEquals(0, seekrit!!.defaultCollection.count)
         seekrit!!.close()
 
         // Make sure it doesn't need a password now:
         seekrit = openSeekrit(null)
-        assertEquals(0, seekrit!!.getDefaultCollection()!!.count)
+        assertEquals(0, seekrit!!.defaultCollection.count)
         seekrit!!.close()
 
         // Make sure old password doesn't work:
@@ -117,7 +117,7 @@ class DatabaseEncryptionTest : BaseDbTest() {
         val body = "This is a blob!".encodeToByteArray()
         var blob = Blob("text/plain", body)
         doc.setValue("blob", blob)
-        seekrit!!.getDefaultCollection()!!.save(doc)
+        seekrit!!.defaultCollection.save(doc)
 
         // Read content from the raw blob file:
         blob = doc.getBlob("blob")!!
@@ -134,7 +134,7 @@ class DatabaseEncryptionTest : BaseDbTest() {
         }
 
         // Check blob content:
-        val savedDoc = seekrit!!.getDefaultCollection()!!.getDocument("att")
+        val savedDoc = seekrit!!.defaultCollection.getDocument("att")
         assertNotNull(savedDoc)
         blob = savedDoc.getBlob("blob")!!
         assertNotNull(blob.digest)

--- a/couchbase-lite-ee/src/jvmCommonMain/ee/kotbase/MessageEndpointListenerConfiguration.jvmCommon.kt
+++ b/couchbase-lite-ee/src/jvmCommonMain/ee/kotbase/MessageEndpointListenerConfiguration.jvmCommon.kt
@@ -29,7 +29,7 @@ internal constructor(
     @Suppress("DEPRECATION")
     @Deprecated(
         "Use MessageEndpointListener(Collection, ProtocolType)",
-        ReplaceWith("MessageEndpointListener(setOf(database.getDefaultCollection()!!), protocolType)")
+        ReplaceWith("MessageEndpointListener(setOf(database.defaultCollection), protocolType)")
     )
     public actual constructor(
         database: Database,
@@ -37,7 +37,7 @@ internal constructor(
     ) : this(
         CBLMessageEndpointListenerConfiguration(database.actual, protocolType),
         database,
-        setOf(database.getDefaultCollection())
+        setOf(database.defaultCollection)
     )
 
     public actual constructor(collections: Set<Collection>, protocolType: ProtocolType) : this(

--- a/couchbase-lite-ee/src/jvmCommonMain/ee/kotbase/URLEndpointListenerConfiguration.jvmCommon.kt
+++ b/couchbase-lite-ee/src/jvmCommonMain/ee/kotbase/URLEndpointListenerConfiguration.jvmCommon.kt
@@ -32,7 +32,7 @@ private constructor(
     @Suppress("DEPRECATION")
     @Deprecated(
         "Use URLEndpointListenerConfiguration(Collections)",
-        ReplaceWith("URLEndpointListenerConfiguration(setOf(database.getDefaultCollection()!!), networkInterface, port, disableTls, identity, authenticator, readOnly, enableDeltaSync)")
+        ReplaceWith("URLEndpointListenerConfiguration(setOf(database.defaultCollection), networkInterface, port, disableTls, identity, authenticator, readOnly, enableDeltaSync)")
     )
     public actual constructor(
         database: Database,
@@ -45,7 +45,7 @@ private constructor(
         enableDeltaSync: Boolean
     ) : this(
         database,
-        setOf(database.getDefaultCollection()),
+        setOf(database.defaultCollection),
         identity,
         authenticator,
         CBLURLEndpointListenerConfiguration(database.actual).apply {

--- a/couchbase-lite-ee/src/linuxMingwMain/ee/kotbase/MessageEndpointListenerConfiguration.linuxMingw.kt
+++ b/couchbase-lite-ee/src/linuxMingwMain/ee/kotbase/MessageEndpointListenerConfiguration.linuxMingw.kt
@@ -24,14 +24,14 @@ internal constructor(
 
     @Deprecated(
         "Use MessageEndpointListener(Collection, ProtocolType)",
-        ReplaceWith("MessageEndpointListener(setOf(database.getDefaultCollection()!!), protocolType)")
+        ReplaceWith("MessageEndpointListener(setOf(database.defaultCollection), protocolType)")
     )
     public actual constructor(
         database: Database,
         protocolType: ProtocolType
     ) : this(
         database,
-        setOf(database.getDefaultCollection()),
+        setOf(database.defaultCollection),
         protocolType
     )
 

--- a/couchbase-lite-ee/src/linuxMingwMain/ee/kotbase/URLEndpointListenerConfiguration.linuxMingw.kt
+++ b/couchbase-lite-ee/src/linuxMingwMain/ee/kotbase/URLEndpointListenerConfiguration.linuxMingw.kt
@@ -23,7 +23,7 @@ public actual class URLEndpointListenerConfiguration private constructor() {
 
     @Deprecated(
         "Use URLEndpointListenerConfiguration(Collections)",
-        ReplaceWith("URLEndpointListenerConfiguration(setOf(database.getDefaultCollection()!!), networkInterface, port, disableTls, identity, authenticator, readOnly, enableDeltaSync)")
+        ReplaceWith("URLEndpointListenerConfiguration(setOf(database.defaultCollection), networkInterface, port, disableTls, identity, authenticator, readOnly, enableDeltaSync)")
     )
     public actual constructor(
         database: Database,

--- a/couchbase-lite-kermit/src/commonTest/kotlin/kotbase/kermit/KermitCouchbaseLiteLoggerTest.kt
+++ b/couchbase-lite-kermit/src/commonTest/kotlin/kotbase/kermit/KermitCouchbaseLiteLoggerTest.kt
@@ -118,7 +118,7 @@ class KermitCouchbaseLiteLoggerTest : BaseTest() {
         logWriter.checkLog(Severity.Info, CBL_DATABASE, "Instantiated")
         logWriter.clearCache()
 
-        database.getDefaultCollection()!!.save(MutableDocument("doc-1", """{"foo":"bar","baz":42}"""))
+        database.defaultCollection.save(MutableDocument("doc-1", """{"foo":"bar","baz":42}"""))
         logWriter.checkLog(Severity.Verbose, CBL_DATABASE, "{DB#", "begin transaction")
         logWriter.checkLog(Severity.Verbose, CBL_DATABASE, "{DB#", "Saved 'doc-1' rev #1-", "as seq 1")
         logWriter.checkLog(Severity.Verbose, CBL_DATABASE, "{DB#", "commit transaction")

--- a/couchbase-lite-ktx/src/commonMain/kotlin/kotbase/ktx/DatabaseExt.kt
+++ b/couchbase-lite-ktx/src/commonMain/kotlin/kotbase/ktx/DatabaseExt.kt
@@ -33,8 +33,8 @@ import kotlin.coroutines.CoroutineContext
  */
 @Suppress("DEPRECATION")
 @Deprecated(
-    "Use getDefaultCollection().documentFlow()",
-    ReplaceWith("getDefaultCollection()!!.documentFlow(id)")
+    "Use defaultCollection.documentFlow()",
+    ReplaceWith("defaultCollection.documentFlow(id)")
 )
 public fun Database.documentFlow(id: String): Flow<Document?> = documentFlow(id, Dispatchers.IO)
 
@@ -48,8 +48,8 @@ public fun Database.documentFlow(id: String): Flow<Document?> = documentFlow(id,
  */
 @Suppress("DEPRECATION")
 @Deprecated(
-    "Use getDefaultCollection().documentFlow()",
-    ReplaceWith("getDefaultCollection()!!.documentFlow(id, fetchContext)")
+    "Use defaultCollection.documentFlow()",
+    ReplaceWith("defaultCollection.documentFlow(id, fetchContext)")
 )
 public fun Database.documentFlow(
     id: String,

--- a/couchbase-lite-ktx/src/commonMain/kotlin/kotbase/ktx/QueryBuilderExtensions.kt
+++ b/couchbase-lite-ktx/src/commonMain/kotlin/kotbase/ktx/QueryBuilderExtensions.kt
@@ -40,7 +40,7 @@ public inline fun all(): SelectResult.From = SelectResult.all()
 @Suppress("DEPRECATION")
 @Deprecated(
     "Use from(Collection)",
-    ReplaceWith("from(database.getDefaultCollection()!!)")
+    ReplaceWith("from(database.defaultCollection)")
 )
 public inline infix fun FromRouter.from(database: Database): From = from(DataSource.database(database))
 

--- a/couchbase-lite-paging/src/commonMain/kotlin/kotbase/paging/QueryPagingSource.kt
+++ b/couchbase-lite-paging/src/commonMain/kotlin/kotbase/paging/QueryPagingSource.kt
@@ -126,7 +126,7 @@ public fun <RowType : Any> QueryPagingSource(
  */
 @Deprecated(
     "Use collection instead of database",
-    ReplaceWith("QueryPagingSource(context, select, database.getDefaultCollection()!!, mapper) { this }")
+    ReplaceWith("QueryPagingSource(context, select, database.defaultCollection, mapper) { this }")
 )
 public fun <RowType : Any> QueryPagingSource(
     context: CoroutineContext,
@@ -135,7 +135,7 @@ public fun <RowType : Any> QueryPagingSource(
     mapper: (Map<String, Any?>) -> RowType
 ): PagingSource<Int, RowType> = OffsetQueryPagingSource(
     select,
-    database.getDefaultCollection(),
+    database.defaultCollection,
     { this },
     context,
     mapMapper = mapper
@@ -164,7 +164,7 @@ public fun <RowType : Any> QueryPagingSource(
  */
 @Deprecated(
     "Use collection instead of database",
-    ReplaceWith("QueryPagingSource(context, select, database.getDefaultCollection()!!, mapper) { this }")
+    ReplaceWith("QueryPagingSource(context, select, database.defaultCollection, mapper) { this }")
 )
 @JvmName("QueryPagingSourceString")
 public fun <RowType : Any> QueryPagingSource(
@@ -174,7 +174,7 @@ public fun <RowType : Any> QueryPagingSource(
     mapper: (String) -> RowType
 ): PagingSource<Int, RowType> = OffsetQueryPagingSource(
     select,
-    database.getDefaultCollection(),
+    database.defaultCollection,
     { this },
     context,
     jsonStringMapper = mapper
@@ -203,7 +203,7 @@ public fun <RowType : Any> QueryPagingSource(
  */
 @Deprecated(
     "Use collection instead of database",
-    ReplaceWith("QueryPagingSource(context, select, database.getDefaultCollection()!!, mapper, queryProvider)")
+    ReplaceWith("QueryPagingSource(context, select, database.defaultCollection, mapper, queryProvider)")
 )
 @JvmName("QueryPagingSourceWithQuery")
 public fun <RowType : Any> QueryPagingSource(
@@ -214,7 +214,7 @@ public fun <RowType : Any> QueryPagingSource(
     queryProvider: From.() -> LimitRouter
 ): PagingSource<Int, RowType> = OffsetQueryPagingSource(
     select,
-    database.getDefaultCollection(),
+    database.defaultCollection,
     queryProvider,
     context,
     mapMapper = mapper
@@ -243,7 +243,7 @@ public fun <RowType : Any> QueryPagingSource(
  */
 @Deprecated(
     "Use collection instead of database",
-    ReplaceWith("QueryPagingSource(context, select, database.getDefaultCollection()!!, mapper, queryProvider)")
+    ReplaceWith("QueryPagingSource(context, select, database.defaultCollection, mapper, queryProvider)")
 )
 @JvmName("QueryPagingSourceStringWithQuery")
 public fun <RowType : Any> QueryPagingSource(
@@ -254,11 +254,8 @@ public fun <RowType : Any> QueryPagingSource(
     queryProvider: From.() -> LimitRouter
 ): PagingSource<Int, RowType> = OffsetQueryPagingSource(
     select,
-    database.getDefaultCollection(),
+    database.defaultCollection,
     queryProvider,
     context,
     jsonStringMapper = mapper
 )
-
-private fun Database.getDefaultCollection(): Collection =
-    requireNotNull(getDefaultCollection()) { "Default collection must exist" }

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/Collection.apple.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/Collection.apple.kt
@@ -212,13 +212,15 @@ internal constructor(
         }
     }
 
-    @Throws(CouchbaseLiteException::class)
-    public actual fun getIndexes(): Set<String> {
-        return wrapCBLError { error ->
-            @Suppress("UNCHECKED_CAST")
-            actual.indexes(error) as List<String>
-        }.toSet()
-    }
+    @Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT") // https://youtrack.jetbrains.com/issue/KT-63047
+    //@get:Throws(CouchbaseLiteException::class)
+    public actual val indexes: Set<String>
+        get() {
+            return wrapCBLError { error ->
+                @Suppress("UNCHECKED_CAST")
+                actual.indexes(error) as List<String>
+            }.toSet()
+        }
 
     @Throws(CouchbaseLiteException::class)
     public actual fun createIndex(name: String, config: IndexConfiguration) {

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/Collection.apple.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/Collection.apple.kt
@@ -225,9 +225,14 @@ internal constructor(
             }.toSet()
         }
 
+    /**
+     * Get a list of the names of indices in the collection.
+     *
+     * @throws CouchbaseLiteException on failure
+     */
     // For Objective-C/Swift throws
     @Throws(CouchbaseLiteException::class)
-    public fun getIndexes(): Set<String> = indexes
+    public fun indexes(): Set<String> = indexes
 
     @Throws(CouchbaseLiteException::class)
     public actual fun createIndex(name: String, config: IndexConfiguration) {

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/Collection.apple.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/Collection.apple.kt
@@ -27,6 +27,7 @@ import kotlinx.datetime.Instant
 import kotlinx.datetime.toKotlinInstant
 import kotlinx.datetime.toNSDate
 import kotlin.coroutines.CoroutineContext
+import kotlin.experimental.ExperimentalObjCRefinement
 
 @OptIn(ExperimentalStdlibApi::class)
 public actual class Collection
@@ -212,6 +213,8 @@ internal constructor(
         }
     }
 
+    @OptIn(ExperimentalObjCRefinement::class)
+    @HiddenFromObjC
     @Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT") // https://youtrack.jetbrains.com/issue/KT-63047
     //@get:Throws(CouchbaseLiteException::class)
     public actual val indexes: Set<String>
@@ -221,6 +224,10 @@ internal constructor(
                 actual.indexes(error) as List<String>
             }.toSet()
         }
+
+    // For Objective-C/Swift throws
+    @Throws(CouchbaseLiteException::class)
+    public fun getIndexes(): Set<String> = indexes
 
     @Throws(CouchbaseLiteException::class)
     public actual fun createIndex(name: String, config: IndexConfiguration) {

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/DataSource.apple.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/DataSource.apple.kt
@@ -49,7 +49,7 @@ private constructor(override var actual: CBLQueryDataSource) : DelegatedClass<CB
 
         @Deprecated(
             "Use DataSource.collection(Collection)",
-            ReplaceWith("collection(database.getDefaultCollection()!!)")
+            ReplaceWith("collection(database.defaultCollection)")
         )
         public actual fun database(database: Database): As =
             As(database = database.actual)

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/Database.apple.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/Database.apple.kt
@@ -510,13 +510,15 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
         "Use defaultCollection.indexes",
         ReplaceWith("defaultCollection.indexes")
     )
-    @Throws(CouchbaseLiteException::class)
-    public actual fun getIndexes(): List<String> {
-        return mustBeOpen {
-            @Suppress("UNCHECKED_CAST")
-            actual.indexes as List<String>
+    @Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT") // https://youtrack.jetbrains.com/issue/KT-63047
+    //@get:Throws(CouchbaseLiteException::class)
+    public actual val indexes: List<String>
+        get() {
+            return mustBeOpen {
+                @Suppress("UNCHECKED_CAST")
+                actual.indexes as List<String>
+            }
         }
-    }
 
     @Deprecated(
         "Use defaultCollection.createIndex()",

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/Database.apple.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/Database.apple.kt
@@ -107,13 +107,15 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
         }
     }
 
-    @Throws(CouchbaseLiteException::class)
-    public actual fun getScopes(): Set<Scope> {
-        return wrapCBLError { error ->
-            @Suppress("UNCHECKED_CAST")
-            actual.scopes(error) as List<CBLScope>
-        }.asScopes(this)
-    }
+    @Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT") // https://youtrack.jetbrains.com/issue/KT-63047
+    //@get:Throws(CouchbaseLiteException::class)
+    public actual val scopes: Set<Scope>
+        get() {
+            return wrapCBLError { error ->
+                @Suppress("UNCHECKED_CAST")
+                actual.scopes(error) as List<CBLScope>
+            }.asScopes(this)
+        }
 
     @Throws(CouchbaseLiteException::class)
     public actual fun getScope(name: String): Scope? {

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/Database.apple.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/Database.apple.kt
@@ -120,9 +120,14 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
             }.asScopes(this)
         }
 
+    /**
+     * Get scope names that have at least one collection.
+     * Note: the default scope is exceptional as it will always be listed even though there are no collections
+     * under it.
+     */
     // For Objective-C/Swift throws
     @Throws(CouchbaseLiteException::class)
-    public fun getScopes(): Set<Scope> = scopes
+    public fun scopes(): Set<Scope> = scopes
 
     @Throws(CouchbaseLiteException::class)
     public actual fun getScope(name: String): Scope? {
@@ -142,9 +147,12 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
             }!!.asScope(this)
         }
 
+    /**
+     * Get the default scope.
+     */
     // For Objective-C/Swift throws
     @Throws(CouchbaseLiteException::class)
-    public fun getDefaultScope(): Scope = defaultScope
+    public fun defaultScope(): Scope = defaultScope
 
     @Throws(CouchbaseLiteException::class)
     public actual fun createCollection(name: String): Collection {
@@ -172,9 +180,12 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
             }.asCollections(this)
         }
 
+    /**
+     * Get all collections in the default scope.
+     */
     // For Objective-C/Swift throws
     @Throws(CouchbaseLiteException::class)
-    public fun getCollections(): Set<Collection> = collections
+    public fun collections(): Set<Collection> = collections
 
     @Throws(CouchbaseLiteException::class)
     public actual fun getCollections(scopeName: String?): Set<Collection> {
@@ -208,9 +219,12 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
         }!!.asCollection(this)
     }
 
+    /**
+     * Get the default collection.
+     */
     // For Objective-C/Swift throws
     @Throws(CouchbaseLiteException::class)
-    public fun getDefaultCollection(): Collection = defaultCollection
+    public fun defaultCollection(): Collection = defaultCollection
 
     @Throws(CouchbaseLiteException::class)
     public actual fun deleteCollection(name: String) {
@@ -547,14 +561,19 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
             }
         }
 
+    /**
+     * Get a list of the names of indices on the default collection.
+     *
+     * @throws CouchbaseLiteException on failure
+     */
     // For Objective-C/Swift throws
     @Suppress("DEPRECATION")
     @Deprecated(
-        "Use defaultCollection.getIndexes()",
-        ReplaceWith("defaultCollection.getIndexes()")
+        "Use defaultCollection().indexes()",
+        ReplaceWith("defaultCollection().indexes()")
     )
     @Throws(CouchbaseLiteException::class)
-    public fun getIndexes(): List<String> = indexes
+    public fun indexes(): List<String> = indexes
 
     @Deprecated(
         "Use defaultCollection.createIndex()",

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/Database.apple.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/Database.apple.kt
@@ -124,12 +124,14 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
         }?.asScope(this)
     }
 
-    @Throws(CouchbaseLiteException::class)
-    public actual fun getDefaultScope(): Scope {
-        return wrapCBLError { error ->
-            actual.defaultScope(error)
-        }!!.asScope(this)
-    }
+    @Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT") // https://youtrack.jetbrains.com/issue/KT-63047
+    //@get:Throws(CouchbaseLiteException::class)
+    public actual val defaultScope: Scope
+        get() {
+            return wrapCBLError { error ->
+                actual.defaultScope(error)
+            }!!.asScope(this)
+        }
 
     @Throws(CouchbaseLiteException::class)
     public actual fun createCollection(name: String): Collection {

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/Database.apple.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/Database.apple.kt
@@ -173,15 +173,13 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
         }?.asCollection(this)
     }
 
-    private val _defaultCollection: Collection by lazy {
+    @Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT") // https://youtrack.jetbrains.com/issue/KT-63047
+    //@get:Throws(CouchbaseLiteException::class)
+    public actual val defaultCollection: Collection by lazy {
         wrapCBLError { error ->
             actual.defaultCollection(error)
         }!!.asCollection(this)
     }
-
-    @Throws(CouchbaseLiteException::class)
-    public actual fun getDefaultCollection(): Collection =
-        _defaultCollection
 
     @Throws(CouchbaseLiteException::class)
     public actual fun deleteCollection(name: String) {
@@ -222,25 +220,25 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
     }
 
     @Deprecated(
-        "Use getDefaultCollection().count",
-        ReplaceWith("getDefaultCollection()!!.count")
+        "Use defaultCollection.count",
+        ReplaceWith("defaultCollection.count")
     )
     public actual val count: Long
         get() = actual.count.toLong()
 
     @Deprecated(
-        "Use getDefaultCollection().getDocument()",
-        ReplaceWith("getDefaultCollection()!!.getDocument(id)")
+        "Use defaultCollection.getDocument()",
+        ReplaceWith("defaultCollection.getDocument(id)")
     )
     public actual fun getDocument(id: String): Document? {
         return mustBeOpen {
-            actual.documentWithID(id)?.asDocument(getDefaultCollection())
+            actual.documentWithID(id)?.asDocument(defaultCollection)
         }
     }
 
     @Deprecated(
-        "Use getDefaultCollection().save()",
-        ReplaceWith("getDefaultCollection()!!.save(document)")
+        "Use defaultCollection.save()",
+        ReplaceWith("defaultCollection.save(document)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun save(document: MutableDocument) {
@@ -252,8 +250,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
     }
 
     @Deprecated(
-        "Use getDefaultCollection().save()",
-        ReplaceWith("getDefaultCollection()!!.save(document, concurrencyControl)")
+        "Use defaultCollection.save()",
+        ReplaceWith("defaultCollection.save(document, concurrencyControl)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun save(
@@ -274,15 +272,15 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
     }
 
     @Deprecated(
-        "Use getDefaultCollection().save()",
-        ReplaceWith("getDefaultCollection()!!.save(document, conflictHandler)")
+        "Use defaultCollection.save()",
+        ReplaceWith("defaultCollection.save(document, conflictHandler)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun save(document: MutableDocument, conflictHandler: ConflictHandler): Boolean {
         return mustBeOpen {
             wrapCBLError { error ->
                 try {
-                    actual.saveDocument(document.actual, conflictHandler.convert(getDefaultCollection()), error)
+                    actual.saveDocument(document.actual, conflictHandler.convert(defaultCollection), error)
                 } catch (e: Exception) {
                     if (e !is CouchbaseLiteException) {
                         throw CouchbaseLiteException(
@@ -302,8 +300,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
     }
 
     @Deprecated(
-        "Use getDefaultCollection().delete()",
-        ReplaceWith("getDefaultCollection()!!.delete(document)")
+        "Use defaultCollection.delete()",
+        ReplaceWith("defaultCollection.delete(document)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun delete(document: Document) {
@@ -315,8 +313,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
     }
 
     @Deprecated(
-        "Use getDefaultCollection().delete()",
-        ReplaceWith("getDefaultCollection().delete(document, concurrencyControl)")
+        "Use defaultCollection.delete()",
+        ReplaceWith("defaultCollection.delete(document, concurrencyControl)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun delete(document: Document, concurrencyControl: ConcurrencyControl): Boolean {
@@ -334,8 +332,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
     }
 
     @Deprecated(
-        "Use getDefaultCollection().purge()",
-        ReplaceWith("getDefaultCollection().purge(document)")
+        "Use defaultCollection.purge()",
+        ReplaceWith("defaultCollection.purge(document)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun purge(document: Document) {
@@ -355,8 +353,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
     }
 
     @Deprecated(
-        "Use getDefaultCollection().purge()",
-        ReplaceWith("getDefaultCollection().purge(id)")
+        "Use defaultCollection.purge()",
+        ReplaceWith("defaultCollection.purge(id)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun purge(id: String) {
@@ -368,8 +366,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
     }
 
     @Deprecated(
-        "Use getDefaultCollection().setDocumentExpiration()",
-        ReplaceWith("getDefaultCollection().setDocumentExpiration(id, expiration)")
+        "Use defaultCollection.setDocumentExpiration()",
+        ReplaceWith("defaultCollection.setDocumentExpiration(id, expiration)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun setDocumentExpiration(id: String, expiration: Instant?) {
@@ -381,8 +379,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
     }
 
     @Deprecated(
-        "Use getDefaultCollection().getDocumentExpiration()",
-        ReplaceWith("getDefaultCollection().getDocumentExpiration(id)")
+        "Use defaultCollection.getDocumentExpiration()",
+        ReplaceWith("defaultCollection.getDocumentExpiration(id)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun getDocumentExpiration(id: String): Instant? {
@@ -393,8 +391,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
 
     @Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
     @Deprecated(
-        "Use getDefaultCollection().addChangeListener()",
-        ReplaceWith("getDefaultCollection().addChangeListener(listener)")
+        "Use defaultCollection.addChangeListener()",
+        ReplaceWith("defaultCollection.addChangeListener(listener)")
     )
     public actual fun addChangeListener(listener: DatabaseChangeListener): ListenerToken {
         return DelegatedListenerToken(
@@ -407,8 +405,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
     @Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
     @OptIn(ExperimentalStdlibApi::class)
     @Deprecated(
-        "Use getDefaultCollection().addChangeListener()",
-        ReplaceWith("getDefaultCollection().addChangeListener(context, listener)")
+        "Use defaultCollection.addChangeListener()",
+        ReplaceWith("defaultCollection.addChangeListener(context, listener)")
     )
     public actual fun addChangeListener(context: CoroutineContext, listener: DatabaseChangeSuspendListener): ListenerToken {
         return mustBeOpen {
@@ -424,8 +422,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
     @Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
     @OptIn(ExperimentalStdlibApi::class)
     @Deprecated(
-        "Use getDefaultCollection().addChangeListener()",
-        ReplaceWith("getDefaultCollection().addChangeListener(scope, listener)")
+        "Use defaultCollection.addChangeListener()",
+        ReplaceWith("defaultCollection.addChangeListener(scope, listener)")
     )
     public actual fun addChangeListener(scope: CoroutineScope, listener: DatabaseChangeSuspendListener) {
         mustBeOpen {
@@ -440,21 +438,21 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
     }
 
     @Deprecated(
-        "Use getDefaultCollection().addDocumentChangeListener()",
-        ReplaceWith("getDefaultCollection().addDocumentChangeListener(id, listener)")
+        "Use defaultCollection.addDocumentChangeListener()",
+        ReplaceWith("defaultCollection.addDocumentChangeListener(id, listener)")
     )
     public actual fun addDocumentChangeListener(id: String, listener: DocumentChangeListener): ListenerToken {
         return DelegatedListenerToken(
             mustBeOpen {
-                actual.addDocumentChangeListenerWithID(id, listener.convert(getDefaultCollection()))
+                actual.addDocumentChangeListenerWithID(id, listener.convert(defaultCollection))
             }
         )
     }
 
     @OptIn(ExperimentalStdlibApi::class)
     @Deprecated(
-        "Use getDefaultCollection().addDocumentChangeListener()",
-        ReplaceWith("getDefaultCollection().addDocumentChangeListener(id, context, listener)")
+        "Use defaultCollection.addDocumentChangeListener()",
+        ReplaceWith("defaultCollection.addDocumentChangeListener(id, context, listener)")
     )
     public actual fun addDocumentChangeListener(
         id: String,
@@ -466,7 +464,7 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
             val token = actual.addDocumentChangeListenerWithID(
                 id,
                 context[CoroutineDispatcher]?.asDispatchQueue(),
-                listener.convert(getDefaultCollection(), scope)
+                listener.convert(defaultCollection, scope)
             )
             SuspendListenerToken(scope, token)
         }
@@ -474,8 +472,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
 
     @OptIn(ExperimentalStdlibApi::class)
     @Deprecated(
-        "Use getDefaultCollection().addDocumentChangeListener()",
-        ReplaceWith("getDefaultCollection().addDocumentChangeListener(id, scope, listener)")
+        "Use defaultCollection.addDocumentChangeListener()",
+        ReplaceWith("defaultCollection.addDocumentChangeListener(id, scope, listener)")
     )
     public actual fun addDocumentChangeListener(
         id: String,
@@ -486,7 +484,7 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
             val token = actual.addDocumentChangeListenerWithID(
                 id,
                 scope.coroutineContext[CoroutineDispatcher]?.asDispatchQueue(),
-                listener.convert(getDefaultCollection(), scope)
+                listener.convert(defaultCollection, scope)
             )
             scope.coroutineContext[Job]?.invokeOnCompletion {
                 actual.removeChangeListenerWithToken(token)
@@ -503,8 +501,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
     }
 
     @Deprecated(
-        "Use getDefaultCollection().indexes",
-        ReplaceWith("getDefaultCollection().indexes")
+        "Use defaultCollection.indexes",
+        ReplaceWith("defaultCollection.indexes")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun getIndexes(): List<String> {
@@ -515,8 +513,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
     }
 
     @Deprecated(
-        "Use getDefaultCollection().createIndex()",
-        ReplaceWith("getDefaultCollection().createIndex(name, index)")
+        "Use defaultCollection.createIndex()",
+        ReplaceWith("defaultCollection.createIndex(name, index)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun createIndex(name: String, index: Index) {
@@ -528,8 +526,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
     }
 
     @Deprecated(
-        "Use getDefaultCollection().createIndex()",
-        ReplaceWith("getDefaultCollection().createIndex(name, config)")
+        "Use defaultCollection.createIndex()",
+        ReplaceWith("defaultCollection.createIndex(name, config)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun createIndex(name: String, config: IndexConfiguration) {
@@ -541,8 +539,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
     }
 
     @Deprecated(
-        "Use getDefaultCollection().deleteIndex()",
-        ReplaceWith("getDefaultCollection().deleteIndex(name)")
+        "Use defaultCollection.deleteIndex()",
+        ReplaceWith("defaultCollection.deleteIndex(name)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun deleteIndex(name: String) {

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/Database.apple.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/Database.apple.kt
@@ -147,13 +147,15 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
         }!!.asCollection(this)
     }
 
-    @Throws(CouchbaseLiteException::class)
-    public actual fun getCollections(): Set<Collection> {
-        return wrapCBLError { error ->
-            @Suppress("UNCHECKED_CAST")
-            actual.collections(null, error) as List<CBLCollection>
-        }.asCollections(this)
-    }
+    @Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT") // https://youtrack.jetbrains.com/issue/KT-63047
+    //@get:Throws(CouchbaseLiteException::class)
+    public actual val collections: Set<Collection>
+        get() {
+            return wrapCBLError { error ->
+                @Suppress("UNCHECKED_CAST")
+                actual.collections(null, error) as List<CBLCollection>
+            }.asCollections(this)
+        }
 
     @Throws(CouchbaseLiteException::class)
     public actual fun getCollections(scopeName: String?): Set<Collection> {

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/Database.apple.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/Database.apple.kt
@@ -29,6 +29,7 @@ import kotlinx.datetime.Instant
 import kotlinx.datetime.toKotlinInstant
 import kotlinx.datetime.toNSDate
 import kotlin.coroutines.CoroutineContext
+import kotlin.experimental.ExperimentalObjCRefinement
 
 @OptIn(ExperimentalStdlibApi::class)
 public actual class Database
@@ -107,6 +108,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
         }
     }
 
+    @OptIn(ExperimentalObjCRefinement::class)
+    @HiddenFromObjC
     @Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT") // https://youtrack.jetbrains.com/issue/KT-63047
     //@get:Throws(CouchbaseLiteException::class)
     public actual val scopes: Set<Scope>
@@ -117,6 +120,10 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
             }.asScopes(this)
         }
 
+    // For Objective-C/Swift throws
+    @Throws(CouchbaseLiteException::class)
+    public fun getScopes(): Set<Scope> = scopes
+
     @Throws(CouchbaseLiteException::class)
     public actual fun getScope(name: String): Scope? {
         return wrapCBLError { error ->
@@ -124,6 +131,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
         }?.asScope(this)
     }
 
+    @OptIn(ExperimentalObjCRefinement::class)
+    @HiddenFromObjC
     @Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT") // https://youtrack.jetbrains.com/issue/KT-63047
     //@get:Throws(CouchbaseLiteException::class)
     public actual val defaultScope: Scope
@@ -132,6 +141,10 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
                 actual.defaultScope(error)
             }!!.asScope(this)
         }
+
+    // For Objective-C/Swift throws
+    @Throws(CouchbaseLiteException::class)
+    public fun getDefaultScope(): Scope = defaultScope
 
     @Throws(CouchbaseLiteException::class)
     public actual fun createCollection(name: String): Collection {
@@ -147,6 +160,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
         }!!.asCollection(this)
     }
 
+    @OptIn(ExperimentalObjCRefinement::class)
+    @HiddenFromObjC
     @Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT") // https://youtrack.jetbrains.com/issue/KT-63047
     //@get:Throws(CouchbaseLiteException::class)
     public actual val collections: Set<Collection>
@@ -156,6 +171,10 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
                 actual.collections(null, error) as List<CBLCollection>
             }.asCollections(this)
         }
+
+    // For Objective-C/Swift throws
+    @Throws(CouchbaseLiteException::class)
+    public fun getCollections(): Set<Collection> = collections
 
     @Throws(CouchbaseLiteException::class)
     public actual fun getCollections(scopeName: String?): Set<Collection> {
@@ -179,6 +198,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
         }?.asCollection(this)
     }
 
+    @OptIn(ExperimentalObjCRefinement::class)
+    @HiddenFromObjC
     @Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT") // https://youtrack.jetbrains.com/issue/KT-63047
     //@get:Throws(CouchbaseLiteException::class)
     public actual val defaultCollection: Collection by lazy {
@@ -186,6 +207,10 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
             actual.defaultCollection(error)
         }!!.asCollection(this)
     }
+
+    // For Objective-C/Swift throws
+    @Throws(CouchbaseLiteException::class)
+    public fun getDefaultCollection(): Collection = defaultCollection
 
     @Throws(CouchbaseLiteException::class)
     public actual fun deleteCollection(name: String) {
@@ -506,6 +531,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
         token.remove()
     }
 
+    @OptIn(ExperimentalObjCRefinement::class)
+    @HiddenFromObjC
     @Deprecated(
         "Use defaultCollection.indexes",
         ReplaceWith("defaultCollection.indexes")
@@ -519,6 +546,15 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
                 actual.indexes as List<String>
             }
         }
+
+    // For Objective-C/Swift throws
+    @Suppress("DEPRECATION")
+    @Deprecated(
+        "Use defaultCollection.getIndexes()",
+        ReplaceWith("defaultCollection.getIndexes()")
+    )
+    @Throws(CouchbaseLiteException::class)
+    public fun getIndexes(): List<String> = indexes
 
     @Deprecated(
         "Use defaultCollection.createIndex()",

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/Replicator.apple.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/Replicator.apple.kt
@@ -82,14 +82,17 @@ internal constructor(
             }
         }
 
+    /**
+     * Get a best effort set of document IDs in the default collection, that are still pending replication.
+     */
     // For Objective-C/Swift throws
     @Suppress("DEPRECATION")
     @Deprecated(
         "Use getPendingDocumentIds(Collection)",
-        ReplaceWith("getPendingDocumentIds(config.database.getDefaultCollection())")
+        ReplaceWith("getPendingDocumentIds(config.database.defaultCollection())")
     )
     @Throws(CouchbaseLiteException::class)
-    public fun getPendingDocumentIds(): Set<String> = pendingDocumentIds
+    public fun pendingDocumentIds(): Set<String> = pendingDocumentIds
 
     @Suppress("DEPRECATION")
     @Throws(CouchbaseLiteException::class)

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/Replicator.apple.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/Replicator.apple.kt
@@ -67,7 +67,7 @@ internal constructor(
     @Suppress("DEPRECATION")
     @Deprecated(
         "Use getPendingDocumentIds(Collection)",
-        ReplaceWith("getPendingDocumentIds(config.database.getDefaultCollection()!!)")
+        ReplaceWith("getPendingDocumentIds(config.database.defaultCollection)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun getPendingDocumentIds(): Set<String> {
@@ -90,7 +90,7 @@ internal constructor(
 
     @Deprecated(
         "Use isDocumentPending(String, Collection)",
-        ReplaceWith("isDocumentPending(docId, config.database.getDefaultCollection()!!)")
+        ReplaceWith("isDocumentPending(docId, config.database.defaultCollection)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun isDocumentPending(docId: String): Boolean {

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/Replicator.apple.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/Replicator.apple.kt
@@ -64,19 +64,20 @@ internal constructor(
     public actual val serverCertificates: List<ByteArray>?
         get() = actual.serverCertificate?.toByteArray()?.let { listOf(it) }
 
-    @Suppress("DEPRECATION")
     @Deprecated(
         "Use getPendingDocumentIds(Collection)",
         ReplaceWith("getPendingDocumentIds(config.database.defaultCollection)")
     )
-    @Throws(CouchbaseLiteException::class)
-    public actual fun getPendingDocumentIds(): Set<String> {
-        config.database.mustBeOpen()
-        return wrapCBLError { error ->
-            @Suppress("UNCHECKED_CAST")
-            actual.pendingDocumentIDs(error) as Set<String>
+    @Suppress("DEPRECATION", "ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT") // https://youtrack.jetbrains.com/issue/KT-63047
+    //@get:Throws(CouchbaseLiteException::class)
+    public actual val pendingDocumentIds: Set<String>
+        get() {
+            config.database.mustBeOpen()
+            return wrapCBLError { error ->
+                @Suppress("UNCHECKED_CAST")
+                actual.pendingDocumentIDs(error) as Set<String>
+            }
         }
-    }
 
     @Suppress("DEPRECATION")
     @Throws(CouchbaseLiteException::class)

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/Replicator.apple.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/Replicator.apple.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlin.coroutines.CoroutineContext
+import kotlin.experimental.ExperimentalObjCRefinement
 
 @OptIn(ExperimentalStdlibApi::class)
 public actual class Replicator
@@ -64,6 +65,8 @@ internal constructor(
     public actual val serverCertificates: List<ByteArray>?
         get() = actual.serverCertificate?.toByteArray()?.let { listOf(it) }
 
+    @OptIn(ExperimentalObjCRefinement::class)
+    @HiddenFromObjC
     @Deprecated(
         "Use getPendingDocumentIds(Collection)",
         ReplaceWith("getPendingDocumentIds(config.database.defaultCollection)")
@@ -78,6 +81,15 @@ internal constructor(
                 actual.pendingDocumentIDs(error) as Set<String>
             }
         }
+
+    // For Objective-C/Swift throws
+    @Suppress("DEPRECATION")
+    @Deprecated(
+        "Use getPendingDocumentIds(Collection)",
+        ReplaceWith("getPendingDocumentIds(config.database.getDefaultCollection())")
+    )
+    @Throws(CouchbaseLiteException::class)
+    public fun getPendingDocumentIds(): Set<String> = pendingDocumentIds
 
     @Suppress("DEPRECATION")
     @Throws(CouchbaseLiteException::class)

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/ReplicatorConfiguration.apple.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/ReplicatorConfiguration.apple.kt
@@ -41,7 +41,7 @@ private constructor(
         target,
         database
     ) {
-        addCollection(database.getDefaultCollection(), null)
+        addCollection(database.defaultCollection, null)
     }
 
     public actual constructor(target: Endpoint) : this(
@@ -309,7 +309,7 @@ private constructor(
 
     @Suppress("DEPRECATION")
     private val defaultCollection: Collection by lazy {
-        database.getDefaultCollection()
+        database.defaultCollection
             ?: throw IllegalArgumentException("Cannot use legacy parameters when there is no default collection")
     }
 

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/ReplicatorConfiguration.apple.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/ReplicatorConfiguration.apple.kt
@@ -34,7 +34,7 @@ private constructor(
 
     @Deprecated(
         "Use ReplicatorConfiguration(Endpoint)",
-        ReplaceWith("ReplicatorConfiguration(target)")
+        ReplaceWith("ReplicatorConfiguration(target).addCollection(database.defaultCollection, null)")
     )
     public actual constructor(database: Database, target: Endpoint) : this(
         CBLReplicatorConfiguration(database.actual, target.actual),

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/ReplicatorConfiguration.apple.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/ReplicatorConfiguration.apple.kt
@@ -308,23 +308,19 @@ private constructor(
         }
 
     @Suppress("DEPRECATION")
-    private val defaultCollection: Collection by lazy {
-        database.defaultCollection
-            ?: throw IllegalArgumentException("Cannot use legacy parameters when there is no default collection")
-    }
-
     private fun getDefaultCollectionConfiguration(): CollectionConfiguration {
-        return collectionConfigurations[defaultCollection]
+        return collectionConfigurations[database.defaultCollection]
             ?: throw IllegalArgumentException(
                 "Cannot use legacy parameters when the default collection has no configuration"
             )
     }
 
+    @Suppress("DEPRECATION")
     private fun updateDefaultConfig(updater: CollectionConfiguration.() -> Unit) {
         val config = getDefaultCollectionConfiguration()
         val updated = CollectionConfiguration(config)
         updated.updater()
-        addCollection(defaultCollection, updated)
+        addCollection(database.defaultCollection, updated)
     }
 
     public override fun toString(): String {

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/Scope.apple.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/Scope.apple.kt
@@ -19,6 +19,7 @@ import cocoapods.CouchbaseLite.CBLCollection
 import cocoapods.CouchbaseLite.CBLScope
 import kotbase.ext.wrapCBLError
 import kotbase.internal.DelegatedClass
+import kotlin.experimental.ExperimentalObjCRefinement
 
 public actual class Scope
 internal constructor(
@@ -29,6 +30,8 @@ internal constructor(
     public actual val name: String
         get() = actual.name
 
+    @OptIn(ExperimentalObjCRefinement::class)
+    @HiddenFromObjC
     @Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT") // https://youtrack.jetbrains.com/issue/KT-63047
     //@get:Throws(CouchbaseLiteException::class)
     public actual val collections: Set<Collection>
@@ -39,6 +42,10 @@ internal constructor(
             }.asCollections(database)
             return collections.toSet()
         }
+
+    // For Objective-C/Swift throws
+    @Throws(CouchbaseLiteException::class)
+    public fun getCollections(): Set<Collection> = collections
 
     @Throws(CouchbaseLiteException::class)
     public actual fun getCollection(collectionName: String): Collection? {

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/Scope.apple.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/Scope.apple.kt
@@ -29,14 +29,16 @@ internal constructor(
     public actual val name: String
         get() = actual.name
 
-    @Throws(CouchbaseLiteException::class)
-    public actual fun getCollections(): Set<Collection> {
-        @Suppress("UNCHECKED_CAST")
-        val collections = wrapCBLError { error ->
-            actual.collections(error) as List<CBLCollection>
-        }.asCollections(database)
-        return collections.toSet()
-    }
+    @Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT") // https://youtrack.jetbrains.com/issue/KT-63047
+    //@get:Throws(CouchbaseLiteException::class)
+    public actual val collections: Set<Collection>
+        get() {
+            @Suppress("UNCHECKED_CAST")
+            val collections = wrapCBLError { error ->
+                actual.collections(error) as List<CBLCollection>
+            }.asCollections(database)
+            return collections.toSet()
+        }
 
     @Throws(CouchbaseLiteException::class)
     public actual fun getCollection(collectionName: String): Collection? {

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/Scope.apple.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/Scope.apple.kt
@@ -43,9 +43,12 @@ internal constructor(
             return collections.toSet()
         }
 
+    /**
+     * Get all collections in the scope.
+     */
     // For Objective-C/Swift throws
     @Throws(CouchbaseLiteException::class)
-    public fun getCollections(): Set<Collection> = collections
+    public fun collections(): Set<Collection> = collections
 
     @Throws(CouchbaseLiteException::class)
     public actual fun getCollection(collectionName: String): Collection? {

--- a/couchbase-lite/src/commonMain/kotlin/kotbase/Collection.kt
+++ b/couchbase-lite/src/commonMain/kotlin/kotbase/Collection.kt
@@ -255,7 +255,6 @@ public expect class Collection : AutoCloseable {
     /**
      * Get a list of the names of indices in the collection.
      *
-     * @return the list of index names
      * @throws CouchbaseLiteException on failure
      */
     @Suppress("WRONG_ANNOTATION_TARGET_WITH_USE_SITE_TARGET")

--- a/couchbase-lite/src/commonMain/kotlin/kotbase/Collection.kt
+++ b/couchbase-lite/src/commonMain/kotlin/kotbase/Collection.kt
@@ -258,8 +258,9 @@ public expect class Collection : AutoCloseable {
      * @return the list of index names
      * @throws CouchbaseLiteException on failure
      */
-    @Throws(CouchbaseLiteException::class)
-    public fun getIndexes(): Set<String>
+    @Suppress("WRONG_ANNOTATION_TARGET_WITH_USE_SITE_TARGET")
+    @get:Throws(CouchbaseLiteException::class)
+    public val indexes: Set<String>
 
     /**
      * Add an index to the collection.

--- a/couchbase-lite/src/commonMain/kotlin/kotbase/CommonFlows.kt
+++ b/couchbase-lite/src/commonMain/kotlin/kotbase/CommonFlows.kt
@@ -106,7 +106,7 @@ public fun Query.queryChangeFlow(coroutineContext: CoroutineContext? = null): Fl
 @Suppress("DEPRECATION")
 @Deprecated(
     "Use Collection.collectionChangeFlow()",
-    ReplaceWith("getDefaultCollection()!!.collectionChangeFlow(coroutineContext)")
+    ReplaceWith("defaultCollection.collectionChangeFlow(coroutineContext)")
 )
 public fun Database.databaseChangeFlow(
     coroutineContext: CoroutineContext? = null
@@ -127,7 +127,7 @@ public fun Database.databaseChangeFlow(
 @Suppress("DEPRECATION")
 @Deprecated(
     "Use Collection.documentChangeFlow()",
-    ReplaceWith("getDefaultCollection()!!.documentChangeFlow(documentId, coroutineContext)")
+    ReplaceWith("defaultCollection.documentChangeFlow(documentId, coroutineContext)")
 )
 public fun Database.documentChangeFlow(
     documentId: String,

--- a/couchbase-lite/src/commonMain/kotlin/kotbase/ConfigurationFactories.kt
+++ b/couchbase-lite/src/commonMain/kotlin/kotbase/ConfigurationFactories.kt
@@ -167,7 +167,7 @@ public fun ReplicatorConfiguration?.newConfig(
         database ?: this?.database ?: throw IllegalArgumentException("A ReplicatorConfiguration must specify a database"),
         target ?: this?.target ?: throw IllegalArgumentException("A ReplicatorConfiguration must specify an endpoint")
     ).apply {
-        val origDefaultConfig = orig?.database?.getDefaultCollection()?.let { orig.getCollectionConfiguration(it) }
+        val origDefaultConfig = orig?.database?.defaultCollection?.let { orig.getCollectionConfiguration(it) }
         (type ?: orig?.type)?.let { this.type = it }
         (continuous ?: orig?.isContinuous)?.let { this.isContinuous = it }
         this.authenticator = authenticator ?: orig?.authenticator

--- a/couchbase-lite/src/commonMain/kotlin/kotbase/DataSource.kt
+++ b/couchbase-lite/src/commonMain/kotlin/kotbase/DataSource.kt
@@ -44,7 +44,7 @@ public expect open class DataSource {
          */
         @Deprecated(
             "Use DataSource.collection(Collection)",
-            ReplaceWith("collection(database.getDefaultCollection()!!)")
+            ReplaceWith("collection(database.defaultCollection)")
         )
         public fun database(database: Database): As
 

--- a/couchbase-lite/src/commonMain/kotlin/kotbase/Database.kt
+++ b/couchbase-lite/src/commonMain/kotlin/kotbase/Database.kt
@@ -169,8 +169,9 @@ public expect class Database : AutoCloseable {
     /**
      * Get all collections in the default scope.
      */
-    @Throws(CouchbaseLiteException::class)
-    public fun getCollections(): Set<Collection>
+    @Suppress("WRONG_ANNOTATION_TARGET_WITH_USE_SITE_TARGET")
+    @get:Throws(CouchbaseLiteException::class)
+    public val collections: Set<Collection>
 
     /**
      * Get all collections in the named scope.

--- a/couchbase-lite/src/commonMain/kotlin/kotbase/Database.kt
+++ b/couchbase-lite/src/commonMain/kotlin/kotbase/Database.kt
@@ -124,8 +124,9 @@ public expect class Database : AutoCloseable {
      * Note: the default scope is exceptional as it will always be listed even though there are no collections
      * under it.
      */
-    @Throws(CouchbaseLiteException::class)
-    public fun getScopes(): Set<Scope>
+    @Suppress("WRONG_ANNOTATION_TARGET_WITH_USE_SITE_TARGET")
+    @get:Throws(CouchbaseLiteException::class)
+    public val scopes: Set<Scope>
 
     /**
      * Get a scope object by name. As the scope cannot exist by itself without having a collection,

--- a/couchbase-lite/src/commonMain/kotlin/kotbase/Database.kt
+++ b/couchbase-lite/src/commonMain/kotlin/kotbase/Database.kt
@@ -534,7 +534,6 @@ public expect class Database : AutoCloseable {
     /**
      * Get a list of the names of indices on the default collection.
      *
-     * @return the list of index names
      * @throws CouchbaseLiteException on failure
      */
     @Deprecated(

--- a/couchbase-lite/src/commonMain/kotlin/kotbase/Database.kt
+++ b/couchbase-lite/src/commonMain/kotlin/kotbase/Database.kt
@@ -202,11 +202,10 @@ public expect class Database : AutoCloseable {
 
     /**
      * Get the default collection.
-     *
-     * @return the default collection.
      */
-    @Throws(CouchbaseLiteException::class)
-    public fun getDefaultCollection(): Collection
+    @Suppress("WRONG_ANNOTATION_TARGET_WITH_USE_SITE_TARGET")
+    @get:Throws(CouchbaseLiteException::class)
+    public val defaultCollection: Collection
 
     /**
      * Delete a collection by name  in the default scope. If the collection doesn't exist, the operation
@@ -252,8 +251,8 @@ public expect class Database : AutoCloseable {
      * The number of documents in the default collection, 0 if database is closed.
      */
     @Deprecated(
-        "Use getDefaultCollection().count",
-        ReplaceWith("getDefaultCollection()!!.count")
+        "Use defaultCollection.count",
+        ReplaceWith("defaultCollection.count")
     )
     public val count: Long
 
@@ -268,8 +267,8 @@ public expect class Database : AutoCloseable {
      * @throws IllegalStateException when the database is closed or the default collection has been deleted
      */
     @Deprecated(
-        "Use getDefaultCollection().getDocument()",
-        ReplaceWith("getDefaultCollection()!!.getDocument(id)")
+        "Use defaultCollection.getDocument()",
+        ReplaceWith("defaultCollection.getDocument(id)")
     )
     public fun getDocument(id: String): Document?
 
@@ -282,8 +281,8 @@ public expect class Database : AutoCloseable {
      * @throws CouchbaseLiteException on error
      */
     @Deprecated(
-        "Use getDefaultCollection().save()",
-        ReplaceWith("getDefaultCollection()!!.save(document)")
+        "Use defaultCollection.save()",
+        ReplaceWith("defaultCollection.save(document)")
     )
     @Throws(CouchbaseLiteException::class)
     public fun save(document: MutableDocument)
@@ -300,8 +299,8 @@ public expect class Database : AutoCloseable {
      * @throws CouchbaseLiteException on error
      */
     @Deprecated(
-        "Use getDefaultCollection().save()",
-        ReplaceWith("getDefaultCollection().save(document, concurrencyControl)")
+        "Use defaultCollection.save()",
+        ReplaceWith("defaultCollection.save(document, concurrencyControl)")
     )
     @Throws(CouchbaseLiteException::class)
     public fun save(document: MutableDocument, concurrencyControl: ConcurrencyControl): Boolean
@@ -315,8 +314,8 @@ public expect class Database : AutoCloseable {
      * @throws CouchbaseLiteException on error
      */
     @Deprecated(
-        "Use getDefaultCollection().save()",
-        ReplaceWith("getDefaultCollection().save(document, conflictHandler)")
+        "Use defaultCollection.save()",
+        ReplaceWith("defaultCollection.save(document, conflictHandler)")
     )
     @Throws(CouchbaseLiteException::class)
     public fun save(document: MutableDocument, conflictHandler: ConflictHandler): Boolean
@@ -330,8 +329,8 @@ public expect class Database : AutoCloseable {
      * @throws CouchbaseLiteException on error
      */
     @Deprecated(
-        "Use getDefaultCollection().delete()",
-        ReplaceWith("getDefaultCollection().delete(document)")
+        "Use defaultCollection.delete()",
+        ReplaceWith("defaultCollection.delete(document)")
     )
     @Throws(CouchbaseLiteException::class)
     public fun delete(document: Document)
@@ -346,8 +345,8 @@ public expect class Database : AutoCloseable {
      * @throws CouchbaseLiteException on error
      */
     @Deprecated(
-        "Use getDefaultCollection().delete()",
-        ReplaceWith("getDefaultCollection().delete(document, concurrencyControl)")
+        "Use defaultCollection.delete()",
+        ReplaceWith("defaultCollection.delete(document, concurrencyControl)")
     )
     @Throws(CouchbaseLiteException::class)
     public fun delete(document: Document, concurrencyControl: ConcurrencyControl): Boolean
@@ -359,8 +358,8 @@ public expect class Database : AutoCloseable {
      * @param document the document to be purged.
      */
     @Deprecated(
-        "Use getDefaultCollection().purge()",
-        ReplaceWith("getDefaultCollection().purge(document)")
+        "Use defaultCollection.purge()",
+        ReplaceWith("defaultCollection.purge(document)")
     )
     @Throws(CouchbaseLiteException::class)
     public fun purge(document: Document)
@@ -372,8 +371,8 @@ public expect class Database : AutoCloseable {
      * @param id the document ID
      */
     @Deprecated(
-        "Use getDefaultCollection().purge()",
-        ReplaceWith("getDefaultCollection().purge(id)")
+        "Use defaultCollection.purge()",
+        ReplaceWith("defaultCollection.purge(id)")
     )
     @Throws(CouchbaseLiteException::class)
     public fun purge(id: String)
@@ -388,8 +387,8 @@ public expect class Database : AutoCloseable {
      * @throws CouchbaseLiteException Throws an exception if any error occurs during the operation.
      */
     @Deprecated(
-        "Use getDefaultCollection().setDocumentExpiration()",
-        ReplaceWith("getDefaultCollection().setDocumentExpiration(id, expiration)")
+        "Use defaultCollection.setDocumentExpiration()",
+        ReplaceWith("defaultCollection.setDocumentExpiration(id, expiration)")
     )
     @Throws(CouchbaseLiteException::class)
     public fun setDocumentExpiration(id: String, expiration: Instant?)
@@ -403,8 +402,8 @@ public expect class Database : AutoCloseable {
      * @throws CouchbaseLiteException Throws an exception if any error occurs during the operation.
      */
     @Deprecated(
-        "Use getDefaultCollection().getDocumentExpiration()",
-        ReplaceWith("getDefaultCollection().getDocumentExpiration(id)")
+        "Use defaultCollection.getDocumentExpiration()",
+        ReplaceWith("defaultCollection.getDocumentExpiration(id)")
     )
     @Throws(CouchbaseLiteException::class)
     public fun getDocumentExpiration(id: String): Instant?
@@ -423,8 +422,8 @@ public expect class Database : AutoCloseable {
      */
     @Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
     @Deprecated(
-        "Use getDefaultCollection().addChangeListener()",
-        ReplaceWith("getDefaultCollection().addChangeListener(listener)")
+        "Use defaultCollection.addChangeListener()",
+        ReplaceWith("defaultCollection.addChangeListener(listener)")
     )
     public fun addChangeListener(listener: DatabaseChangeListener): ListenerToken
 
@@ -442,8 +441,8 @@ public expect class Database : AutoCloseable {
      */
     @Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
     @Deprecated(
-        "Use getDefaultCollection().addChangeListener()",
-        ReplaceWith("getDefaultCollection().addChangeListener(context, listener)")
+        "Use defaultCollection.addChangeListener()",
+        ReplaceWith("defaultCollection.addChangeListener(context, listener)")
     )
     public fun addChangeListener(context: CoroutineContext, listener: DatabaseChangeSuspendListener): ListenerToken
 
@@ -458,8 +457,8 @@ public expect class Database : AutoCloseable {
      */
     @Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
     @Deprecated(
-        "Use getDefaultCollection().addChangeListener()",
-        ReplaceWith("getDefaultCollection().addChangeListener(scope, listener)")
+        "Use defaultCollection.addChangeListener()",
+        ReplaceWith("defaultCollection.addChangeListener(scope, listener)")
     )
     public fun addChangeListener(scope: CoroutineScope, listener: DatabaseChangeSuspendListener)
 
@@ -476,8 +475,8 @@ public expect class Database : AutoCloseable {
      * @see ListenerToken.remove
      */
     @Deprecated(
-        "Use getDefaultCollection().addDocumentChangeListener()",
-        ReplaceWith("getDefaultCollection().addDocumentChangeListener(id, listener)")
+        "Use defaultCollection.addDocumentChangeListener()",
+        ReplaceWith("defaultCollection.addDocumentChangeListener(id, listener)")
     )
     public fun addDocumentChangeListener(id: String, listener: DocumentChangeListener): ListenerToken
 
@@ -494,8 +493,8 @@ public expect class Database : AutoCloseable {
      * @see ListenerToken.remove
      */
     @Deprecated(
-        "Use getDefaultCollection().addDocumentChangeListener()",
-        ReplaceWith("getDefaultCollection().addDocumentChangeListener(id, context, listener)")
+        "Use defaultCollection.addDocumentChangeListener()",
+        ReplaceWith("defaultCollection.addDocumentChangeListener(id, context, listener)")
     )
     public fun addDocumentChangeListener(
         id: String,
@@ -513,8 +512,8 @@ public expect class Database : AutoCloseable {
      * @param listener callback
      */
     @Deprecated(
-        "Use getDefaultCollection().addDocumentChangeListener()",
-        ReplaceWith("getDefaultCollection().addDocumentChangeListener(id, scope, listener)")
+        "Use defaultCollection.addDocumentChangeListener()",
+        ReplaceWith("defaultCollection.addDocumentChangeListener(id, scope, listener)")
     )
     public fun addDocumentChangeListener(id: String, scope: CoroutineScope, listener: DocumentChangeSuspendListener)
 
@@ -536,8 +535,8 @@ public expect class Database : AutoCloseable {
      * @throws CouchbaseLiteException on failure
      */
     @Deprecated(
-        "Use getDefaultCollection().indexes",
-        ReplaceWith("getDefaultCollection().indexes")
+        "Use defaultCollection.indexes",
+        ReplaceWith("defaultCollection.indexes")
     )
     @Throws(CouchbaseLiteException::class)
     public fun getIndexes(): List<String>
@@ -550,8 +549,8 @@ public expect class Database : AutoCloseable {
      * @throws CouchbaseLiteException on failure
      */
     @Deprecated(
-        "Use getDefaultCollection().createIndex()",
-        ReplaceWith("getDefaultCollection().createIndex(name, index)")
+        "Use defaultCollection.createIndex()",
+        ReplaceWith("defaultCollection.createIndex(name, index)")
     )
     @Throws(CouchbaseLiteException::class)
     public fun createIndex(name: String, index: Index)
@@ -564,8 +563,8 @@ public expect class Database : AutoCloseable {
      * @throws CouchbaseLiteException on failure
      */
     @Deprecated(
-        "Use getDefaultCollection().createIndex()",
-        ReplaceWith("getDefaultCollection().createIndex(name, config)")
+        "Use defaultCollection.createIndex()",
+        ReplaceWith("defaultCollection.createIndex(name, config)")
     )
     @Throws(CouchbaseLiteException::class)
     public fun createIndex(name: String, config: IndexConfiguration)
@@ -577,8 +576,8 @@ public expect class Database : AutoCloseable {
      * @throws CouchbaseLiteException on failure
      */
     @Deprecated(
-        "Use getDefaultCollection().deleteIndex()",
-        ReplaceWith("getDefaultCollection().deleteIndex(name)")
+        "Use defaultCollection.deleteIndex()",
+        ReplaceWith("defaultCollection.deleteIndex(name)")
     )
     @Throws(CouchbaseLiteException::class)
     public fun deleteIndex(name: String)
@@ -596,8 +595,8 @@ public expect class Database : AutoCloseable {
  * @param key The key.
  */
 @Deprecated(
-    "Use getDefaultCollection().get()",
-    ReplaceWith("getDefaultCollection()[key]")
+    "Use defaultCollection.get()",
+    ReplaceWith("defaultCollection[key]")
 )
 @Suppress("DEPRECATION")
 public operator fun Database.get(key: String): DocumentFragment =

--- a/couchbase-lite/src/commonMain/kotlin/kotbase/Database.kt
+++ b/couchbase-lite/src/commonMain/kotlin/kotbase/Database.kt
@@ -267,7 +267,7 @@ public expect class Database : AutoCloseable {
      *
      * @param id the document ID
      * @return the Document object or null
-     * @throws IllegalStateException when the database is closed or the default collection has been deleted
+     * @throws IllegalStateException when the database is closed
      */
     @Deprecated(
         "Use defaultCollection.getDocument()",
@@ -541,8 +541,9 @@ public expect class Database : AutoCloseable {
         "Use defaultCollection.indexes",
         ReplaceWith("defaultCollection.indexes")
     )
-    @Throws(CouchbaseLiteException::class)
-    public fun getIndexes(): List<String>
+    @Suppress("WRONG_ANNOTATION_TARGET_WITH_USE_SITE_TARGET")
+    @get:Throws(CouchbaseLiteException::class)
+    public val indexes: List<String>
 
     /**
      * Add an index to the default collection.

--- a/couchbase-lite/src/commonMain/kotlin/kotbase/Database.kt
+++ b/couchbase-lite/src/commonMain/kotlin/kotbase/Database.kt
@@ -139,8 +139,9 @@ public expect class Database : AutoCloseable {
     /**
      * Get the default scope.
      */
-    @Throws(CouchbaseLiteException::class)
-    public fun getDefaultScope(): Scope
+    @Suppress("WRONG_ANNOTATION_TARGET_WITH_USE_SITE_TARGET")
+    @get:Throws(CouchbaseLiteException::class)
+    public val defaultScope: Scope
 
     /**
      * Create a named collection in the default scope.

--- a/couchbase-lite/src/commonMain/kotlin/kotbase/Replicator.kt
+++ b/couchbase-lite/src/commonMain/kotlin/kotbase/Replicator.kt
@@ -75,9 +75,7 @@ constructor(config: ReplicatorConfiguration) : AutoCloseable {
     public val serverCertificates: List<ByteArray>?
 
     /**
-     * Get a best effort list of documents in the default collection, that are still pending replication.
-     *
-     * @return a set of ids for documents in the default collection still awaiting replication.
+     * Get a best effort set of document IDs in the default collection, that are still pending replication.
      */
     @Deprecated(
         "Use getPendingDocumentIds(Collection)",

--- a/couchbase-lite/src/commonMain/kotlin/kotbase/Replicator.kt
+++ b/couchbase-lite/src/commonMain/kotlin/kotbase/Replicator.kt
@@ -83,8 +83,9 @@ constructor(config: ReplicatorConfiguration) : AutoCloseable {
         "Use getPendingDocumentIds(Collection)",
         ReplaceWith("getPendingDocumentIds(config.database.defaultCollection)")
     )
-    @Throws(CouchbaseLiteException::class)
-    public fun getPendingDocumentIds(): Set<String>
+    @Suppress("WRONG_ANNOTATION_TARGET_WITH_USE_SITE_TARGET")
+    @get:Throws(CouchbaseLiteException::class)
+    public val pendingDocumentIds: Set<String>
 
     /**
      * Get a best effort list of documents in the passed collection that are still pending replication.

--- a/couchbase-lite/src/commonMain/kotlin/kotbase/Replicator.kt
+++ b/couchbase-lite/src/commonMain/kotlin/kotbase/Replicator.kt
@@ -81,7 +81,7 @@ constructor(config: ReplicatorConfiguration) : AutoCloseable {
      */
     @Deprecated(
         "Use getPendingDocumentIds(Collection)",
-        ReplaceWith("getPendingDocumentIds(config.database.getDefaultCollection()!!)")
+        ReplaceWith("getPendingDocumentIds(config.database.defaultCollection)")
     )
     @Throws(CouchbaseLiteException::class)
     public fun getPendingDocumentIds(): Set<String>
@@ -102,7 +102,7 @@ constructor(config: ReplicatorConfiguration) : AutoCloseable {
      */
     @Deprecated(
         "Use isDocumentPending(String, Collection)",
-        ReplaceWith("isDocumentPending(docId, config.database.getDefaultCollection()!!)")
+        ReplaceWith("isDocumentPending(docId, config.database.defaultCollection)")
     )
     @Throws(CouchbaseLiteException::class)
     public fun isDocumentPending(docId: String): Boolean

--- a/couchbase-lite/src/commonMain/kotlin/kotbase/ReplicatorConfiguration.kt
+++ b/couchbase-lite/src/commonMain/kotlin/kotbase/ReplicatorConfiguration.kt
@@ -30,7 +30,7 @@ public expect class ReplicatorConfiguration {
      */
     @Deprecated(
         "Use ReplicatorConfiguration(Endpoint)",
-        ReplaceWith("ReplicatorConfiguration(target)")
+        ReplaceWith("ReplicatorConfiguration(target).addCollection(database.defaultCollection, null)")
     )
     public constructor(database: Database, target: Endpoint)
 

--- a/couchbase-lite/src/commonMain/kotlin/kotbase/Scope.kt
+++ b/couchbase-lite/src/commonMain/kotlin/kotbase/Scope.kt
@@ -38,8 +38,6 @@ public expect class Scope {
 
     /**
      * Get all collections in the scope.
-     *
-     * @return a set of all collections in the scope
      */
     @Suppress("WRONG_ANNOTATION_TARGET_WITH_USE_SITE_TARGET")
     @get:Throws(CouchbaseLiteException::class)

--- a/couchbase-lite/src/commonMain/kotlin/kotbase/Scope.kt
+++ b/couchbase-lite/src/commonMain/kotlin/kotbase/Scope.kt
@@ -41,8 +41,9 @@ public expect class Scope {
      *
      * @return a set of all collections in the scope
      */
-    @Throws(CouchbaseLiteException::class)
-    public fun getCollections(): Set<Collection>
+    @Suppress("WRONG_ANNOTATION_TARGET_WITH_USE_SITE_TARGET")
+    @get:Throws(CouchbaseLiteException::class)
+    public val collections: Set<Collection>
 
     /**
      * Get the named collection for the scope.

--- a/couchbase-lite/src/commonTest/kotlin/kotbase/CollectionQueryTest.kt
+++ b/couchbase-lite/src/commonTest/kotlin/kotbase/CollectionQueryTest.kt
@@ -33,7 +33,7 @@ class CollectionQueryTest : BaseQueryTest() {
     @Test
     fun testQueryDefaultCollectionA() {
         val defaultCollection = testDatabase.defaultCollection
-        assertNotNull(defaultCollection!!)
+        assertNotNull(defaultCollection)
         loadJSONResourceIntoCollection("names_100.json", collection = defaultCollection)
 
         // create with _
@@ -56,7 +56,7 @@ class CollectionQueryTest : BaseQueryTest() {
     @Test
     fun testQueryDefaultCollectionB() {
         val defaultCollection = testDatabase.defaultCollection
-        assertNotNull(defaultCollection!!)
+        assertNotNull(defaultCollection)
         loadJSONResourceIntoCollection("names_100.json", collection = defaultCollection)
         verifyQuery(
             QueryBuilder.createQuery("SELECT name.first FROM _default ORDER BY name.first LIMIT 1", testDatabase),
@@ -77,7 +77,7 @@ class CollectionQueryTest : BaseQueryTest() {
     @Test
     fun testQueryDefaultCollectionC() {
         val defaultCollection = testDatabase.defaultCollection
-        assertNotNull(defaultCollection!!)
+        assertNotNull(defaultCollection)
         loadJSONResourceIntoCollection("names_100.json", collection = defaultCollection)
         val query = QueryBuilder.createQuery(
             "SELECT name.first FROM " + testDatabase.name + " ORDER BY name.first LIMIT 1",
@@ -305,7 +305,7 @@ class CollectionQueryTest : BaseQueryTest() {
     @Test
     fun testFTSQueryWithFullTextIndexInDefaultCollectionA() {
         val defaultCollection = testDatabase.defaultCollection
-        assertNotNull(defaultCollection!!)
+        assertNotNull(defaultCollection)
 
         loadJSONResourceIntoCollection("sentences.json", collection = defaultCollection)
 
@@ -333,7 +333,7 @@ class CollectionQueryTest : BaseQueryTest() {
     @Test
     fun testFTSQueryWithFullTextIndexInDefaultCollectionB() {
         val defaultCollection = testDatabase.defaultCollection
-        assertNotNull(defaultCollection!!)
+        assertNotNull(defaultCollection)
 
         loadJSONResourceIntoCollection("sentences.json", collection = defaultCollection)
 
@@ -361,7 +361,7 @@ class CollectionQueryTest : BaseQueryTest() {
     @Test
     fun testFTSQueryWithFullTextIndexInDefaultCollectionC() {
         val defaultCollection = testDatabase.defaultCollection
-        assertNotNull(defaultCollection!!)
+        assertNotNull(defaultCollection)
 
         loadJSONResourceIntoCollection("sentences.json", collection = defaultCollection)
 
@@ -389,7 +389,7 @@ class CollectionQueryTest : BaseQueryTest() {
     @Test
     fun testFTSQueryWithFullTextIndexInDefaultCollectionD() {
         val defaultCollection = testDatabase.defaultCollection
-        assertNotNull(defaultCollection!!)
+        assertNotNull(defaultCollection)
 
         loadJSONResourceIntoCollection("sentences.json", collection = defaultCollection)
 
@@ -417,7 +417,7 @@ class CollectionQueryTest : BaseQueryTest() {
     @Test
     fun testFTSQueryWithFullTextIndexInDefaultCollectionE() {
         val defaultCollection = testDatabase.defaultCollection
-        assertNotNull(defaultCollection!!)
+        assertNotNull(defaultCollection)
 
         loadJSONResourceIntoCollection("sentences.json", collection = defaultCollection)
 
@@ -619,7 +619,7 @@ class CollectionQueryTest : BaseQueryTest() {
     @Test
     fun testSelectAllResultKeyA() {
         val defaultCollection = testDatabase.defaultCollection
-        assertNotNull(defaultCollection!!)
+        assertNotNull(defaultCollection)
 
         var doc = MutableDocument()
         doc.setValue("name", "rose")
@@ -645,7 +645,7 @@ class CollectionQueryTest : BaseQueryTest() {
     @Test
     fun testSelectAllResultKeyB() {
         val defaultCollection = testDatabase.defaultCollection
-        assertNotNull(defaultCollection!!)
+        assertNotNull(defaultCollection)
 
         var doc = MutableDocument()
         doc.setValue("name", "rose")
@@ -671,7 +671,7 @@ class CollectionQueryTest : BaseQueryTest() {
     @Test
     fun testSelectAllResultKeyC() {
         val defaultCollection = testDatabase.defaultCollection
-        assertNotNull(defaultCollection!!)
+        assertNotNull(defaultCollection)
 
         var doc = MutableDocument()
         doc.setValue("name", "rose")
@@ -752,7 +752,7 @@ class CollectionQueryTest : BaseQueryTest() {
     @Test
     fun testQueryBuilderWithDefaultCollectionAsDataSource() {
         val defaultCollection = testDatabase.defaultCollection
-        assertNotNull(defaultCollection!!)
+        assertNotNull(defaultCollection)
         loadJSONResourceIntoCollection("names_100.json", collection = defaultCollection)
 
         // create with default collection
@@ -908,7 +908,7 @@ class CollectionQueryTest : BaseQueryTest() {
     @Test
     fun testBuilderSelectAllResultKeyC() {
         val defaultCollection = testDatabase.defaultCollection
-        assertNotNull(defaultCollection!!)
+        assertNotNull(defaultCollection)
 
         var doc = MutableDocument()
         doc.setValue("name", "rose")

--- a/couchbase-lite/src/commonTest/kotlin/kotbase/CollectionQueryTest.kt
+++ b/couchbase-lite/src/commonTest/kotlin/kotbase/CollectionQueryTest.kt
@@ -32,7 +32,7 @@ class CollectionQueryTest : BaseQueryTest() {
     // Ensure that the result set has one result, and the data is { "first" : "Abe"}.
     @Test
     fun testQueryDefaultCollectionA() {
-        val defaultCollection = testDatabase.getDefaultCollection()
+        val defaultCollection = testDatabase.defaultCollection
         assertNotNull(defaultCollection!!)
         loadJSONResourceIntoCollection("names_100.json", collection = defaultCollection)
 
@@ -55,7 +55,7 @@ class CollectionQueryTest : BaseQueryTest() {
     // Ensure that the result set has one result, and the data is { "first" : "Abe"}.
     @Test
     fun testQueryDefaultCollectionB() {
-        val defaultCollection = testDatabase.getDefaultCollection()
+        val defaultCollection = testDatabase.defaultCollection
         assertNotNull(defaultCollection!!)
         loadJSONResourceIntoCollection("names_100.json", collection = defaultCollection)
         verifyQuery(
@@ -76,7 +76,7 @@ class CollectionQueryTest : BaseQueryTest() {
     // Ensure that the result set has one result, and the data is { "first" : "Abe"}.
     @Test
     fun testQueryDefaultCollectionC() {
-        val defaultCollection = testDatabase.getDefaultCollection()
+        val defaultCollection = testDatabase.defaultCollection
         assertNotNull(defaultCollection!!)
         loadJSONResourceIntoCollection("names_100.json", collection = defaultCollection)
         val query = QueryBuilder.createQuery(
@@ -304,7 +304,7 @@ class CollectionQueryTest : BaseQueryTest() {
     //     <index-name>
     @Test
     fun testFTSQueryWithFullTextIndexInDefaultCollectionA() {
-        val defaultCollection = testDatabase.getDefaultCollection()
+        val defaultCollection = testDatabase.defaultCollection
         assertNotNull(defaultCollection!!)
 
         loadJSONResourceIntoCollection("sentences.json", collection = defaultCollection)
@@ -332,7 +332,7 @@ class CollectionQueryTest : BaseQueryTest() {
     //     _.<index-name>
     @Test
     fun testFTSQueryWithFullTextIndexInDefaultCollectionB() {
-        val defaultCollection = testDatabase.getDefaultCollection()
+        val defaultCollection = testDatabase.defaultCollection
         assertNotNull(defaultCollection!!)
 
         loadJSONResourceIntoCollection("sentences.json", collection = defaultCollection)
@@ -360,7 +360,7 @@ class CollectionQueryTest : BaseQueryTest() {
     //     _default.<index-name>
     @Test
     fun testFTSQueryWithFullTextIndexInDefaultCollectionC() {
-        val defaultCollection = testDatabase.getDefaultCollection()
+        val defaultCollection = testDatabase.defaultCollection
         assertNotNull(defaultCollection!!)
 
         loadJSONResourceIntoCollection("sentences.json", collection = defaultCollection)
@@ -388,7 +388,7 @@ class CollectionQueryTest : BaseQueryTest() {
     //     <database-name>.<index-name>
     @Test
     fun testFTSQueryWithFullTextIndexInDefaultCollectionD() {
-        val defaultCollection = testDatabase.getDefaultCollection()
+        val defaultCollection = testDatabase.defaultCollection
         assertNotNull(defaultCollection!!)
 
         loadJSONResourceIntoCollection("sentences.json", collection = defaultCollection)
@@ -416,7 +416,7 @@ class CollectionQueryTest : BaseQueryTest() {
     //     <collection-alias-name>.<index-name>
     @Test
     fun testFTSQueryWithFullTextIndexInDefaultCollectionE() {
-        val defaultCollection = testDatabase.getDefaultCollection()
+        val defaultCollection = testDatabase.defaultCollection
         assertNotNull(defaultCollection!!)
 
         loadJSONResourceIntoCollection("sentences.json", collection = defaultCollection)
@@ -618,7 +618,7 @@ class CollectionQueryTest : BaseQueryTest() {
     //     SELECT * FROM db => “db”
     @Test
     fun testSelectAllResultKeyA() {
-        val defaultCollection = testDatabase.getDefaultCollection()
+        val defaultCollection = testDatabase.defaultCollection
         assertNotNull(defaultCollection!!)
 
         var doc = MutableDocument()
@@ -644,7 +644,7 @@ class CollectionQueryTest : BaseQueryTest() {
     //     SELECT * FROM _ => “_”
     @Test
     fun testSelectAllResultKeyB() {
-        val defaultCollection = testDatabase.getDefaultCollection()
+        val defaultCollection = testDatabase.defaultCollection
         assertNotNull(defaultCollection!!)
 
         var doc = MutableDocument()
@@ -670,7 +670,7 @@ class CollectionQueryTest : BaseQueryTest() {
     //     SELECT * FROM _default._default => “_default”
     @Test
     fun testSelectAllResultKeyC() {
-        val defaultCollection = testDatabase.getDefaultCollection()
+        val defaultCollection = testDatabase.defaultCollection
         assertNotNull(defaultCollection!!)
 
         var doc = MutableDocument()
@@ -751,7 +751,7 @@ class CollectionQueryTest : BaseQueryTest() {
     // Ensure that the result set has one result, and the data is {"first" : "Abe"}.
     @Test
     fun testQueryBuilderWithDefaultCollectionAsDataSource() {
-        val defaultCollection = testDatabase.getDefaultCollection()
+        val defaultCollection = testDatabase.defaultCollection
         assertNotNull(defaultCollection!!)
         loadJSONResourceIntoCollection("names_100.json", collection = defaultCollection)
 
@@ -907,7 +907,7 @@ class CollectionQueryTest : BaseQueryTest() {
     //     SELECT * FROM _default._default => “_default”
     @Test
     fun testBuilderSelectAllResultKeyC() {
-        val defaultCollection = testDatabase.getDefaultCollection()
+        val defaultCollection = testDatabase.defaultCollection
         assertNotNull(defaultCollection!!)
 
         var doc = MutableDocument()

--- a/couchbase-lite/src/commonTest/kotlin/kotbase/CollectionTest.kt
+++ b/couchbase-lite/src/commonTest/kotlin/kotbase/CollectionTest.kt
@@ -1160,7 +1160,7 @@ class CollectionTest : BaseDbTest() {
         val collection = testDatabase.defaultCollection
         assertEquals(collection.name, Collection.DEFAULT_NAME)
 
-        val cols = testDatabase.getCollections()
+        val cols = testDatabase.collections
         assertTrue(cols.contains(collection))
 
         val scope = collection.scope

--- a/couchbase-lite/src/commonTest/kotlin/kotbase/CollectionTest.kt
+++ b/couchbase-lite/src/commonTest/kotlin/kotbase/CollectionTest.kt
@@ -1173,7 +1173,7 @@ class CollectionTest : BaseDbTest() {
 
     @Test
     fun testDefaultScopeExists() {
-        val scope = testDatabase.getDefaultScope()
+        val scope = testDatabase.defaultScope
         assertNotNull(scope)
         assertEquals(Scope.DEFAULT_NAME, scope.name)
 
@@ -1208,7 +1208,7 @@ class CollectionTest : BaseDbTest() {
             testDatabase.deleteCollection(Collection.DEFAULT_NAME)
         }
 
-        val scope = testDatabase.getDefaultScope()
+        val scope = testDatabase.defaultScope
         assertEquals(Scope.DEFAULT_NAME, scope.name)
 
         val scopes = testDatabase.scopes

--- a/couchbase-lite/src/commonTest/kotlin/kotbase/CollectionTest.kt
+++ b/couchbase-lite/src/commonTest/kotlin/kotbase/CollectionTest.kt
@@ -1177,7 +1177,7 @@ class CollectionTest : BaseDbTest() {
         assertNotNull(scope)
         assertEquals(Scope.DEFAULT_NAME, scope.name)
 
-        val scopes = testDatabase.getScopes()
+        val scopes = testDatabase.scopes
         assertTrue(scopes.contains(scope))
 
         val scope1 = testDatabase.getScope(Scope.DEFAULT_NAME)
@@ -1211,7 +1211,7 @@ class CollectionTest : BaseDbTest() {
         val scope = testDatabase.getDefaultScope()
         assertEquals(Scope.DEFAULT_NAME, scope.name)
 
-        val scopes = testDatabase.getScopes()
+        val scopes = testDatabase.scopes
         assertTrue(scopes.contains(scope))
     }
 }

--- a/couchbase-lite/src/commonTest/kotlin/kotbase/CollectionTest.kt
+++ b/couchbase-lite/src/commonTest/kotlin/kotbase/CollectionTest.kt
@@ -601,21 +601,21 @@ class CollectionTest : BaseDbTest() {
 
     @Test
     fun testCreateIndexInCollection() {
-        assertEquals(0, testCollection.getIndexes().size)
+        assertEquals(0, testCollection.indexes.size)
 
         testCollection.createIndex("index1", ValueIndexConfiguration("firstName", "lastName"))
-        assertEquals(1, testCollection.getIndexes().size)
+        assertEquals(1, testCollection.indexes.size)
 
         testCollection.createIndex("index2", FullTextIndexConfiguration("detail").ignoreAccents(true).setLanguage("es"))
-        assertEquals(2, testCollection.getIndexes().size)
+        assertEquals(2, testCollection.indexes.size)
 
-        assertContents(testCollection.getIndexes().toList(), "index1", "index2")
-        assertTrue(testCollection.getIndexes().contains("index2"))
+        assertContents(testCollection.indexes.toList(), "index1", "index2")
+        assertTrue(testCollection.indexes.contains("index2"))
     }
 
     @Test
     fun testCreateIndexInCollectionWithBuilder() {
-        assertEquals(0, testCollection.getIndexes().size.toLong())
+        assertEquals(0, testCollection.indexes.size.toLong())
         testCollection.createIndex(
             "index1",
             IndexBuilder.valueIndex(
@@ -623,16 +623,16 @@ class CollectionTest : BaseDbTest() {
                 ValueIndexItem.property("lastName")
             )
         )
-        assertEquals(1, testCollection.getIndexes().size.toLong())
+        assertEquals(1, testCollection.indexes.size.toLong())
 
         // Create FTS index:
         testCollection.createIndex("index2", IndexBuilder.fullTextIndex(FullTextIndexItem.property("detail")))
-        assertEquals(2, testCollection.getIndexes().size.toLong())
+        assertEquals(2, testCollection.indexes.size.toLong())
         testCollection.createIndex(
             "index3",
             IndexBuilder.fullTextIndex(FullTextIndexItem.property("es-detail")).ignoreAccents(true).setLanguage("es")
         )
-        assertEquals(3, testCollection.getIndexes().size.toLong())
+        assertEquals(3, testCollection.indexes.size.toLong())
 
         // Create value index with expression() instead of property()
         testCollection.createIndex(
@@ -642,19 +642,19 @@ class CollectionTest : BaseDbTest() {
                 ValueIndexItem.expression(Expression.property("lastName"))
             )
         )
-        assertEquals(4, testCollection.getIndexes().size.toLong())
-        assertContents(testCollection.getIndexes().toList(), "index1", "index2", "index3", "index4")
+        assertEquals(4, testCollection.indexes.size.toLong())
+        assertContents(testCollection.indexes.toList(), "index1", "index2", "index3", "index4")
     }
 
     @Test
     fun testCreateSameIndexTwice() {
         testCollection.createIndex("myindex", ValueIndexConfiguration("firstName", "lastName"))
-        assertEquals(1, testCollection.getIndexes().size)
+        assertEquals(1, testCollection.indexes.size)
 
         // Call create index again:
         testCollection.createIndex("myindex", ValueIndexConfiguration("firstName", "lastName"))
 
-        assertContents(testCollection.getIndexes().toList(), "myindex")
+        assertContents(testCollection.indexes.toList(), "myindex")
     }
 
     @Test
@@ -666,13 +666,13 @@ class CollectionTest : BaseDbTest() {
         testCollection.createIndex("myindex", ValueIndexConfiguration("lastName"))
 
         // Check:
-        assertContents(testCollection.getIndexes().toList(), "myindex")
+        assertContents(testCollection.indexes.toList(), "myindex")
 
         // Do it one more time
         testCollection.createIndex("myindex", ValueIndexConfiguration("detail"))
 
         // Check:
-        assertContents(testCollection.getIndexes().toList(), "myindex")
+        assertContents(testCollection.indexes.toList(), "myindex")
     }
 
     // Test create index from a deleted collection
@@ -717,7 +717,7 @@ class CollectionTest : BaseDbTest() {
     fun testGetIndexFromDeletedCollection() {
         // Delete collection
         testCollection.delete()
-        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.getIndexes() }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.indexes }
     }
 
     @Test
@@ -738,17 +738,17 @@ class CollectionTest : BaseDbTest() {
     @Test
     fun testGetIndexFromCollectionDeletedFromADifferentDBInstance() {
         duplicateDb(testDatabase).use { it.getSimilarCollection(testCollection).delete() }
-        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.getIndexes() }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.indexes }
     }
 
     // Test that getIndexes from collection in closed database causes CBLException
     @Test
     fun testGetIndexesFromCollectionFromClosedDatabase() {
         testCollection.createIndex("index1", ValueIndexConfiguration("firstName", "lastName"))
-        assertContents(testCollection.getIndexes().toList(), "index1")
+        assertContents(testCollection.indexes.toList(), "index1")
 
         closeDb(testDatabase)
-        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.getIndexes() }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.indexes }
     }
 
     // Test that getIndexes from collection in deleted database causes CBLException
@@ -756,25 +756,25 @@ class CollectionTest : BaseDbTest() {
     fun testGetIndexesFromCollectionFromDeletedDatabase() {
 
         testCollection.createIndex("index1", ValueIndexConfiguration("firstName", "lastName"))
-        assertContents(testCollection.getIndexes().toList(), "index1")
+        assertContents(testCollection.indexes.toList(), "index1")
 
         deleteDb(testDatabase)
-        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.getIndexes() }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { testCollection.indexes }
     }
 
     @Test
     fun testDeleteIndex() {
         testCollection.createIndex("index1", ValueIndexConfiguration("firstName", "lastName"))
         testCollection.createIndex("index2", FullTextIndexConfiguration("detail").ignoreAccents(true).setLanguage("es"))
-        assertContents(testCollection.getIndexes().toList(), "index1", "index2")
+        assertContents(testCollection.indexes.toList(), "index1", "index2")
 
         // Delete indexes:
         testCollection.deleteIndex("index2")
-        assertEquals(1, testCollection.getIndexes().size)
-        assertContents(testCollection.getIndexes().toList(), "index1")
+        assertEquals(1, testCollection.indexes.size)
+        assertContents(testCollection.indexes.toList(), "index1")
 
         testCollection.deleteIndex("index1")
-        assertTrue(testCollection.getIndexes().isEmpty())
+        assertTrue(testCollection.indexes.isEmpty())
     }
 
     // Test deleting an index twice
@@ -782,17 +782,17 @@ class CollectionTest : BaseDbTest() {
     fun testDeleteIndexTwice() {
         testCollection.createIndex("index1", ValueIndexConfiguration("firstName", "lastName"))
         testCollection.createIndex("index2", FullTextIndexConfiguration("detail").ignoreAccents(true).setLanguage("es"))
-        assertContents(testCollection.getIndexes().toList(), "index1", "index2")
+        assertContents(testCollection.indexes.toList(), "index1", "index2")
 
         // Delete index2:
         testCollection.deleteIndex("index2")
-        assertEquals(1, testCollection.getIndexes().size)
-        assertTrue(testCollection.getIndexes().contains("index1"))
+        assertEquals(1, testCollection.indexes.size)
+        assertTrue(testCollection.indexes.contains("index1"))
 
         // Do it again
         testCollection.deleteIndex("index2")
-        assertEquals(1, testCollection.getIndexes().size)
-        assertTrue(testCollection.getIndexes().contains("index1"))
+        assertEquals(1, testCollection.indexes.size)
+        assertTrue(testCollection.indexes.contains("index1"))
     }
 
     // Test getting index from a deleted collection causes CBL exception
@@ -800,18 +800,18 @@ class CollectionTest : BaseDbTest() {
     fun testDeleteNonExistentIndex() {
         testCollection.createIndex("index1", ValueIndexConfiguration("firstName", "lastName"))
         testCollection.createIndex("index2", FullTextIndexConfiguration("detail").ignoreAccents(true).setLanguage("es"))
-        assertContents(testCollection.getIndexes().toList(), "index1", "index2")
+        assertContents(testCollection.indexes.toList(), "index1", "index2")
 
         testCollection.deleteIndex("dummy")
 
-        assertContents(testCollection.getIndexes().toList(), "index1", "index2")
+        assertContents(testCollection.indexes.toList(), "index1", "index2")
     }
 
     // Test delete index from a deletedCollection
     @Test
     fun testDeleteIndexFromDeletedCollection() {
         testCollection.createIndex("index1", ValueIndexConfiguration("firstName", "lastName"))
-        assertContents(testCollection.getIndexes().toList(), "index1")
+        assertContents(testCollection.indexes.toList(), "index1")
 
         // Delete collection
         testCollection.delete()
@@ -826,7 +826,7 @@ class CollectionTest : BaseDbTest() {
     @Test
     fun testDeleteIndexFromCollectionDeletedInDifferentDbInstance() {
         testCollection.createIndex("index1", ValueIndexConfiguration("firstName", "lastName"))
-        assertContents(testCollection.getIndexes().toList(), "index1")
+        assertContents(testCollection.indexes.toList(), "index1")
 
         duplicateDb(testDatabase).use { it.getSimilarCollection(testCollection).delete() }
 
@@ -841,7 +841,7 @@ class CollectionTest : BaseDbTest() {
     @Test
     fun testDeleteIndexInCollectionInClosedDatabase() {
         testCollection.createIndex("index1", ValueIndexConfiguration("firstName", "lastName"))
-        assertContents(testCollection.getIndexes().toList(), "index1")
+        assertContents(testCollection.indexes.toList(), "index1")
 
         closeDb(testDatabase)
         assertThrowsCBLException(
@@ -854,7 +854,7 @@ class CollectionTest : BaseDbTest() {
     @Test
     fun testDeleteIndexInCollectionInDeletedDatabase() {
         testCollection.createIndex("index1", ValueIndexConfiguration("firstName", "lastName"))
-        assertContents(testCollection.getIndexes().toList(), "index1")
+        assertContents(testCollection.indexes.toList(), "index1")
 
         deleteDb(testDatabase)
         assertThrowsCBLException(

--- a/couchbase-lite/src/commonTest/kotlin/kotbase/CollectionTest.kt
+++ b/couchbase-lite/src/commonTest/kotlin/kotbase/CollectionTest.kt
@@ -1029,7 +1029,7 @@ class CollectionTest : BaseDbTest() {
     //    Check that the full-name is “_default._default”.
     @Test
     fun testGetFullNameFromDefaultCollection() {
-        assertEquals("_default._default", testDatabase.getDefaultCollection().fullName)
+        assertEquals("_default._default", testDatabase.defaultCollection.fullName)
     }
 
     // 3.2 TestGetFullNameFromNewCollectionInDefaultScope
@@ -1157,7 +1157,7 @@ class CollectionTest : BaseDbTest() {
 
     @Test
     fun testDefaultCollectionExists() {
-        val collection = testDatabase.getDefaultCollection()
+        val collection = testDatabase.defaultCollection
         assertEquals(collection.name, Collection.DEFAULT_NAME)
 
         val cols = testDatabase.getCollections()
@@ -1191,7 +1191,7 @@ class CollectionTest : BaseDbTest() {
             testDatabase.deleteCollection(Collection.DEFAULT_NAME)
         }
 
-        var collection = testDatabase.getDefaultCollection()
+        var collection = testDatabase.defaultCollection
         assertNotNull(collection)
         assertEquals(Collection.DEFAULT_NAME, collection.name)
         assertEquals(Scope.DEFAULT_NAME, collection.scope.name)

--- a/couchbase-lite/src/commonTest/kotlin/kotbase/DatabaseTest.kt
+++ b/couchbase-lite/src/commonTest/kotlin/kotbase/DatabaseTest.kt
@@ -873,7 +873,7 @@ class DatabaseTest : BaseDbTest() {
 
         assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.purge(doc.id) }
 
-        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.getIndexes() }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.indexes }
 
         assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.deleteIndex("foo") }
 
@@ -916,7 +916,7 @@ class DatabaseTest : BaseDbTest() {
 
             assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.purge(doc.id) }
 
-            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.getIndexes() }
+            assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.indexes }
 
             assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { collection.deleteIndex("foo") }
 
@@ -1259,7 +1259,7 @@ class DatabaseTest : BaseDbTest() {
 
     @Test
     fun testCreateIndex() {
-        assertEquals(0, testCollection.getIndexes().size)
+        assertEquals(0, testCollection.indexes.size)
 
         testCollection.createIndex(
             "index1",
@@ -1268,17 +1268,17 @@ class DatabaseTest : BaseDbTest() {
                 ValueIndexItem.property("lastName")
             )
         )
-        assertEquals(1, testCollection.getIndexes().size)
+        assertEquals(1, testCollection.indexes.size)
 
         // Create FTS index:
         testCollection.createIndex("index2", IndexBuilder.fullTextIndex(FullTextIndexItem.property("detail")))
-        assertEquals(2, testCollection.getIndexes().size)
+        assertEquals(2, testCollection.indexes.size)
 
         testCollection.createIndex(
             "index3",
             IndexBuilder.fullTextIndex(FullTextIndexItem.property("es-detail")).ignoreAccents(true).setLanguage("es")
         )
-        assertEquals(3, testCollection.getIndexes().size)
+        assertEquals(3, testCollection.indexes.size)
 
         // Create value index with expression() instead of property()
         testCollection.createIndex(
@@ -1288,25 +1288,25 @@ class DatabaseTest : BaseDbTest() {
                 ValueIndexItem.expression(Expression.property("lastName"))
             )
         )
-        assertEquals(4, testCollection.getIndexes().size)
+        assertEquals(4, testCollection.indexes.size)
 
-        assertContents(testCollection.getIndexes(), "index1", "index2", "index3", "index4")
+        assertContents(testCollection.indexes, "index1", "index2", "index3", "index4")
     }
 
     @Test
     fun testCreateIndexWithConfig() {
-        assertEquals(0, testCollection.getIndexes().size)
+        assertEquals(0, testCollection.indexes.size)
 
         testCollection.createIndex("index1", ValueIndexConfiguration("firstName", "lastName"))
-        assertEquals(1, testCollection.getIndexes().size)
+        assertEquals(1, testCollection.indexes.size)
 
         testCollection.createIndex(
             "index2",
             FullTextIndexConfiguration("detail").ignoreAccents(true).setLanguage("es")
         )
-        assertEquals(2, testCollection.getIndexes().size)
+        assertEquals(2, testCollection.indexes.size)
 
-        assertContents(testCollection.getIndexes(), "index1", "index2")
+        assertContents(testCollection.indexes, "index1", "index2")
     }
 
     @Test
@@ -1324,32 +1324,32 @@ class DatabaseTest : BaseDbTest() {
         // Create index with first name:
         val index: Index = IndexBuilder.valueIndex(ValueIndexItem.property("firstName"))
         testCollection.createIndex("myindex", index)
-        assertEquals(1, testCollection.getIndexes().size)
+        assertEquals(1, testCollection.indexes.size)
 
         // Call create index again:
         testCollection.createIndex("myindex", index)
-        assertEquals(1, testCollection.getIndexes().size)
+        assertEquals(1, testCollection.indexes.size)
 
-        assertContents(testCollection.getIndexes(), "myindex")
+        assertContents(testCollection.indexes, "myindex")
     }
 
     @Test
     fun testCreateSameNameIndexes() {
         // Create value index with first name:
         testCollection.createIndex("myindex", IndexBuilder.valueIndex(ValueIndexItem.property("firstName")))
-        assertEquals(1, testCollection.getIndexes().size)
+        assertEquals(1, testCollection.indexes.size)
 
         // Create value index with last name:
         testCollection.createIndex("myindex", IndexBuilder.valueIndex(ValueIndexItem.property("lastName")))
-        assertEquals(1, testCollection.getIndexes().size)
+        assertEquals(1, testCollection.indexes.size)
 
-        assertContents(testCollection.getIndexes(), "myindex")
+        assertContents(testCollection.indexes, "myindex")
 
         // Create FTS index:
         testCollection.createIndex("myindex", IndexBuilder.fullTextIndex(FullTextIndexItem.property("detail")))
-        assertEquals(1, testCollection.getIndexes().size)
+        assertEquals(1, testCollection.indexes.size)
 
-        assertContents(testCollection.getIndexes(), "myindex")
+        assertContents(testCollection.indexes, "myindex")
     }
 
     @Test
@@ -1358,20 +1358,20 @@ class DatabaseTest : BaseDbTest() {
 
         // Delete indexes:
         testCollection.deleteIndex("index4")
-        assertEquals(3, testCollection.getIndexes().size)
-        assertContents(testCollection.getIndexes(), "index1", "index2", "index3")
+        assertEquals(3, testCollection.indexes.size)
+        assertContents(testCollection.indexes, "index1", "index2", "index3")
 
         testCollection.deleteIndex("index1")
-        assertEquals(2, testCollection.getIndexes().size)
-        assertContents(testCollection.getIndexes(), "index2", "index3")
+        assertEquals(2, testCollection.indexes.size)
+        assertContents(testCollection.indexes, "index2", "index3")
 
         testCollection.deleteIndex("index2")
-        assertEquals(1, testCollection.getIndexes().size)
-        assertContents(testCollection.getIndexes(), "index3")
+        assertEquals(1, testCollection.indexes.size)
+        assertContents(testCollection.indexes, "index3")
 
         testCollection.deleteIndex("index3")
-        assertEquals(0, testCollection.getIndexes().size)
-        assertTrue(testCollection.getIndexes().isEmpty())
+        assertEquals(0, testCollection.indexes.size)
+        assertTrue(testCollection.indexes.isEmpty())
     }
 
     @Test
@@ -1385,13 +1385,13 @@ class DatabaseTest : BaseDbTest() {
     @Test
     fun testDeleteDeletedIndexes() {
         createTestIndexes()
-        assertEquals(4, testCollection.getIndexes().size)
+        assertEquals(4, testCollection.indexes.size)
 
         testCollection.deleteIndex("index1")
         testCollection.deleteIndex("index2")
         testCollection.deleteIndex("index3")
         testCollection.deleteIndex("index4")
-        assertEquals(0, testCollection.getIndexes().size)
+        assertEquals(0, testCollection.indexes.size)
 
         // Delete deleted indexes:
         testCollection.deleteIndex("index1")

--- a/couchbase-lite/src/commonTest/kotlin/kotbase/DatabaseTest.kt
+++ b/couchbase-lite/src/commonTest/kotlin/kotbase/DatabaseTest.kt
@@ -938,10 +938,10 @@ class DatabaseTest : BaseDbTest() {
 
         val scope = testDatabase.getScope("horo")
         assertNotNull(scope!!)
-        assertNotNull(scope.getCollections())
+        assertNotNull(scope.collections)
 
         testDatabase.close()
-        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { scope.getCollections() }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { scope.collections }
     }
 
     @Test
@@ -950,7 +950,7 @@ class DatabaseTest : BaseDbTest() {
 
         val scope = testDatabase.getScope("horo")
         assertNotNull(scope!!)
-        assertNotNull(scope.getCollections())
+        assertNotNull(scope.collections)
 
         testDatabase.close()
         assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { scope.getCollection("bobblehead") }
@@ -968,10 +968,10 @@ class DatabaseTest : BaseDbTest() {
         val scope = testDatabase.getScope("horo")
 
         assertNotNull(scope!!)
-        assertNotNull(scope.getCollections())
+        assertNotNull(scope.collections)
 
         testDatabase.delete()
-        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { scope.getCollections() }
+        assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { scope.collections }
     }
 
     @Test
@@ -980,7 +980,7 @@ class DatabaseTest : BaseDbTest() {
         val scope = testDatabase.getScope("horo")
 
         assertNotNull(scope!!)
-        assertNotNull(scope.getCollections())
+        assertNotNull(scope.collections)
 
         testDatabase.delete()
         assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.NOT_OPEN) { scope.getCollection("bobblehead") }
@@ -1064,7 +1064,7 @@ class DatabaseTest : BaseDbTest() {
         (0..4).map { StringUtils.getUniqueName("test-collection", 4) }
             .forEach { testDatabase.createCollection(it, scope.name) }
 
-        val collectionNames = scope.getCollections().map { it.name }
+        val collectionNames = scope.collections.map { it.name }
         assertEquals(6, collectionNames.size)
 
         // verify that the collections exist
@@ -1076,7 +1076,7 @@ class DatabaseTest : BaseDbTest() {
         // verify that the collections no longer exist
         collectionNames.forEach { assertNull(scope.getCollection(it)) }
 
-        val collections = scope.getCollections()
+        val collections = scope.collections
         assertNotNull(collections)
         assertTrue(collections.isEmpty())
     }
@@ -1099,7 +1099,7 @@ class DatabaseTest : BaseDbTest() {
         (0..4).map { StringUtils.getUniqueName("test-collection", 4) }
             .forEach { testDatabase.createCollection(it, scope.name) }
 
-        val collectionNames = scope.getCollections().map { it.name }
+        val collectionNames = scope.collections.map { it.name }
         assertEquals(6, collectionNames.size)
 
         // verify that the collections exist
@@ -1118,13 +1118,13 @@ class DatabaseTest : BaseDbTest() {
 
             // verify that the collections no longer exist in the other db
             collectionNames.forEach { assertNull(otherDatabase.getCollection(it, otherScope.name)) }
-            val otherCollections = otherScope.getCollections()
+            val otherCollections = otherScope.collections
             assertNotNull(otherCollections)
             assertTrue(otherCollections.isEmpty())
 
             // verify that the collections no longer exist in the original db
             collectionNames.forEach { assertNull(scope.getCollection(it)) }
-            val collections = scope.getCollections()
+            val collections = scope.collections
             assertNotNull(collections)
             assertTrue(collections.isEmpty())
         }

--- a/couchbase-lite/src/commonTest/kotlin/kotbase/DbCollectionsTest.kt
+++ b/couchbase-lite/src/commonTest/kotlin/kotbase/DbCollectionsTest.kt
@@ -28,7 +28,7 @@ class DbCollectionsTest : BaseDbTest() {
     fun testGetDefaultScope() {
         val scope = testDatabase.getDefaultScope()
         assertNotNull(scope)
-        assertTrue(testDatabase.getScopes().contains(scope))
+        assertTrue(testDatabase.scopes.contains(scope))
         assertEquals(Scope.DEFAULT_NAME, scope.name)
         assertEquals(1, scope.collectionCount)
         assertNotNull(scope.getCollection(Collection.DEFAULT_NAME))
@@ -187,7 +187,7 @@ class DbCollectionsTest : BaseDbTest() {
 
     @Test
     fun testGetScopes() {
-        val scopes = testDatabase.getScopes()
+        val scopes = testDatabase.scopes
         assertEquals(2, scopes.size)
 
         var scope = scopes.first { it.name == Scope.DEFAULT_NAME }
@@ -199,12 +199,12 @@ class DbCollectionsTest : BaseDbTest() {
 
     @Test
     fun testDeleteCollectionFromNamedScope() {
-        var scopes = testDatabase.getScopes()
+        var scopes = testDatabase.scopes
         assertEquals(2, scopes.size)
 
         testDatabase.deleteCollection(testCollection.name, testCollection.scope.name)
 
-        scopes = testDatabase.getScopes()
+        scopes = testDatabase.scopes
         assertEquals(1, scopes.size)
 
         val recreateCol = testDatabase.createCollection(testCollection.name, testCollection.scope.name)
@@ -213,7 +213,7 @@ class DbCollectionsTest : BaseDbTest() {
 
     @Test
     fun testDeleteDefaultCollection() {
-        val scopes = testDatabase.getScopes()
+        val scopes = testDatabase.scopes
 
         // scopes should have a default scope and a non default test scope created in BaseDbTest
         assertEquals(2, scopes.size)
@@ -236,7 +236,7 @@ class DbCollectionsTest : BaseDbTest() {
     fun testDeleteAllCollectionsInNamedScope() {
         testDatabase.deleteCollection(testCollection.name, testCollection.scope.name)
         assertNull(testDatabase.getScope(testCollection.name))
-        assertEquals(setOf(testDatabase.getDefaultScope()), testDatabase.getScopes())
+        assertEquals(setOf(testDatabase.getDefaultScope()), testDatabase.scopes)
     }
 
     @Test

--- a/couchbase-lite/src/commonTest/kotlin/kotbase/DbCollectionsTest.kt
+++ b/couchbase-lite/src/commonTest/kotlin/kotbase/DbCollectionsTest.kt
@@ -40,7 +40,7 @@ class DbCollectionsTest : BaseDbTest() {
         assertNotNull(col)
         assertEquals(Collection.DEFAULT_NAME, col.name)
         assertEquals(col, testDatabase.getCollection(Collection.DEFAULT_NAME))
-        assertTrue(testDatabase.getCollections().contains(col))
+        assertTrue(testDatabase.collections.contains(col))
         assertNotNull(col.scope)
         assertEquals(Scope.DEFAULT_NAME, col.scope.name)
         assertEquals(0, col.count)

--- a/couchbase-lite/src/commonTest/kotlin/kotbase/DbCollectionsTest.kt
+++ b/couchbase-lite/src/commonTest/kotlin/kotbase/DbCollectionsTest.kt
@@ -26,7 +26,7 @@ class DbCollectionsTest : BaseDbTest() {
 
     @Test
     fun testGetDefaultScope() {
-        val scope = testDatabase.getDefaultScope()
+        val scope = testDatabase.defaultScope
         assertNotNull(scope)
         assertTrue(testDatabase.scopes.contains(scope))
         assertEquals(Scope.DEFAULT_NAME, scope.name)
@@ -56,7 +56,7 @@ class DbCollectionsTest : BaseDbTest() {
         testDatabase.createCollection("6hintz")
         testDatabase.createCollection("-Ch1ntz")
 
-        val scope = testDatabase.getDefaultScope()
+        val scope = testDatabase.defaultScope
         assertEquals(5, scope.collectionCount)
         assertNotNull(scope.getCollection("chintz"))
         assertNotNull(scope.getCollection("Chintz"))
@@ -112,7 +112,7 @@ class DbCollectionsTest : BaseDbTest() {
         testDatabase.createCollection("chintz", "3icro")
         testDatabase.createCollection("chintz", "-micro")
 
-        var scope: Scope? = testDatabase.getDefaultScope()
+        var scope: Scope? = testDatabase.defaultScope
         assertEquals(1, scope?.collectionCount)
 
         // get non-existing collection returns null
@@ -218,7 +218,7 @@ class DbCollectionsTest : BaseDbTest() {
         // scopes should have a default scope and a non default test scope created in BaseDbTest
         assertEquals(2, scopes.size)
 
-        val scope = testDatabase.getDefaultScope()
+        val scope = testDatabase.defaultScope
         assertEquals(1, scope.collectionCount)
 
         assertThrowsCBLException(CBLError.Domain.CBLITE, CBLError.Code.INVALID_PARAMETER) {
@@ -227,7 +227,7 @@ class DbCollectionsTest : BaseDbTest() {
 
         // Creating the default collection just returns it
         assertEquals(
-            testDatabase.getDefaultScope().getCollection(Collection.DEFAULT_NAME),
+            testDatabase.defaultScope.getCollection(Collection.DEFAULT_NAME),
             testDatabase.createCollection(Collection.DEFAULT_NAME, Scope.DEFAULT_NAME))
     }
 
@@ -236,7 +236,7 @@ class DbCollectionsTest : BaseDbTest() {
     fun testDeleteAllCollectionsInNamedScope() {
         testDatabase.deleteCollection(testCollection.name, testCollection.scope.name)
         assertNull(testDatabase.getScope(testCollection.name))
-        assertEquals(setOf(testDatabase.getDefaultScope()), testDatabase.scopes)
+        assertEquals(setOf(testDatabase.defaultScope), testDatabase.scopes)
     }
 
     @Test

--- a/couchbase-lite/src/commonTest/kotlin/kotbase/DbCollectionsTest.kt
+++ b/couchbase-lite/src/commonTest/kotlin/kotbase/DbCollectionsTest.kt
@@ -36,7 +36,7 @@ class DbCollectionsTest : BaseDbTest() {
 
     @Test
     fun testGetDefaultCollection() {
-        val col = testDatabase.getDefaultCollection()
+        val col = testDatabase.defaultCollection
         assertNotNull(col)
         assertEquals(Collection.DEFAULT_NAME, col.name)
         assertEquals(col, testDatabase.getCollection(Collection.DEFAULT_NAME))

--- a/couchbase-lite/src/commonTest/kotlin/kotbase/DeprecatedConfigFactoryTest.kt
+++ b/couchbase-lite/src/commonTest/kotlin/kotbase/DeprecatedConfigFactoryTest.kt
@@ -82,11 +82,11 @@ class DeprecatedConfigFactoryTest : BaseDbTest() {
     @Test
     fun testReplicatorConfigFromCollectionWithDefault() {
         val config1 = ReplicatorConfigurationFactory
-            .newConfig(testEndpoint, mapOf(listOf(testDatabase.getDefaultCollection()!!) to CollectionConfiguration()))
+            .newConfig(testEndpoint, mapOf(listOf(testDatabase.defaultCollection) to CollectionConfiguration()))
         val config2 = config1.newConfig()
         assertNotSame(config1, config2)
         assertEquals(config1.database, config2.database)
-        assertEquals(setOf(testCollection.database.getDefaultCollection()), config2.collections)
+        assertEquals(setOf(testCollection.database.defaultCollection), config2.collections)
     }
 
     // Create from a source with default collection, explicitly specifying a non-default collection
@@ -103,7 +103,7 @@ class DeprecatedConfigFactoryTest : BaseDbTest() {
         assertEquals(config1.database, config2.database)
 
         val db = config1.database
-        val defaultCollection = db.getDefaultCollection()!!
+        val defaultCollection = db.defaultCollection
 
         assertEquals(setOf(defaultCollection), config2.collections)
         assertEquals(filter, config2.getCollectionConfiguration(defaultCollection)?.pushFilter)
@@ -115,7 +115,7 @@ class DeprecatedConfigFactoryTest : BaseDbTest() {
         val config = ReplicatorConfigurationFactory.newConfig(testDatabase, testEndpoint, channels = listOf("boop"))
         assertEquals(testDatabase, config.database)
         assertEquals(testEndpoint, config.target)
-        assertEquals(listOf("boop"), config.getCollectionConfiguration(testDatabase.getDefaultCollection()!!)!!.channels)
+        assertEquals(listOf("boop"), config.getCollectionConfiguration(testDatabase.defaultCollection)!!.channels)
     }
 
     // Create a collection style config from one built with the legacy call
@@ -127,7 +127,7 @@ class DeprecatedConfigFactoryTest : BaseDbTest() {
         assertEquals(testEndpoint, config2.target)
         val colls = config2.collections
         assertEquals(1, colls.size)
-        val defaultCollection = testDatabase.getDefaultCollection()!!
+        val defaultCollection = testDatabase.defaultCollection
         assertTrue(colls.contains(defaultCollection))
         assertEquals(listOf("boop"), config2.getCollectionConfiguration(defaultCollection)!!.channels)
     }

--- a/couchbase-lite/src/commonTest/kotlin/kotbase/FlowTest.kt
+++ b/couchbase-lite/src/commonTest/kotlin/kotbase/FlowTest.kt
@@ -64,7 +64,7 @@ class FlowTest : BaseReplicatorTest() {
                 for (i in 0..9) {
                     val doc = MutableDocument("doc-${i}")
                     doc.setValue("type", "demo")
-                    saveDocInCollection(doc, testDatabase.getDefaultCollection()!!)
+                    saveDocInCollection(doc, testDatabase.defaultCollection)
                 }
             }
 

--- a/couchbase-lite/src/commonTest/kotlin/kotbase/MigrationTest.kt
+++ b/couchbase-lite/src/commonTest/kotlin/kotbase/MigrationTest.kt
@@ -51,7 +51,7 @@ class MigrationTest : BaseTest() {
         ZipUtils.unzip(PlatformUtils.getAsset("replacedb/android140-sqlite.cblite2.zip")!!, dbDir)
 
         migrationTestDb = openDatabase()
-        val migrationTestCollection = migrationTestDb!!.getDefaultCollection()
+        val migrationTestCollection = migrationTestDb!!.defaultCollection
         assertNotNull(migrationTestCollection)
         assertEquals(2, migrationTestCollection.count)
         for (i in 1..2) {
@@ -76,7 +76,7 @@ class MigrationTest : BaseTest() {
         ZipUtils.unzip(PlatformUtils.getAsset("replacedb/android140-sqlite-noattachment.cblite2.zip")!!, dbDir)
 
         migrationTestDb = openDatabase()
-        val migrationTestCollection = migrationTestDb!!.getDefaultCollection()
+        val migrationTestCollection = migrationTestDb!!.defaultCollection
         assertNotNull(migrationTestCollection)
 
         assertEquals(2, migrationTestCollection.count)
@@ -92,7 +92,7 @@ class MigrationTest : BaseTest() {
         ZipUtils.unzip(PlatformUtils.getAsset("replacedb/android200-sqlite.cblite2.zip")!!, dbDir)
 
         migrationTestDb = openDatabase()
-        val migrationTestCollection = migrationTestDb!!.getDefaultCollection()
+        val migrationTestCollection = migrationTestDb!!.defaultCollection
         assertNotNull(migrationTestCollection)
 
         assertEquals(2, migrationTestCollection.count)

--- a/couchbase-lite/src/commonTest/kotlin/kotbase/NotificationTest.kt
+++ b/couchbase-lite/src/commonTest/kotlin/kotbase/NotificationTest.kt
@@ -329,7 +329,7 @@ class NotificationTest : BaseDbTest() {
 //
 //        val latch3 = CountDownLatch(2)
 //        testDatabase.addChangeListener { latch3.countDown() }.use { ignore1 ->
-//            defaultCollection!!.addChangeListener { latch3.countDown() }.use {
+//            defaultCollection.addChangeListener { latch3.countDown() }.use {
 //                assertEquals(2, defaultCollection.getCollectionListenerCount())
 //                saveDocsInCollection(createTestDocs(1000, 10), defaultCollection)
 //                assertTrue(latch3.await(STD_TIMEOUT_SEC.seconds))
@@ -339,7 +339,7 @@ class NotificationTest : BaseDbTest() {
 //
 //        val latch4 = CountDownLatch(2)
 //        testDatabase.addChangeListener { latch4.countDown() }.use {
-//            defaultCollection!!.addChangeListener { latch4.countDown() }.use {
+//            defaultCollection.addChangeListener { latch4.countDown() }.use {
 //                assertEquals(2, defaultCollection.getCollectionListenerCount())
 //                saveDocsInCollection(createTestDocs(2000, 10), defaultCollection)
 //                assertTrue(latch4.await(STD_TIMEOUT_SEC.seconds))

--- a/couchbase-lite/src/commonTest/kotlin/kotbase/NotificationTest.kt
+++ b/couchbase-lite/src/commonTest/kotlin/kotbase/NotificationTest.kt
@@ -315,7 +315,7 @@ class NotificationTest : BaseDbTest() {
 //    @Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
 //    @Test
 //    fun testLegacyChangeAPI() = runBlocking {
-//        val defaultCollection = testDatabase.getDefaultCollection()
+//        val defaultCollection = testDatabase.defaultCollection
 //
 //        val latch1 = CountDownLatch(1)
 //        val dbListener: DatabaseChangeListener = { latch1.countDown() }

--- a/couchbase-lite/src/commonTest/kotlin/kotbase/QueryTest.kt
+++ b/couchbase-lite/src/commonTest/kotlin/kotbase/QueryTest.kt
@@ -3014,7 +3014,7 @@ class QueryTest : BaseQueryTest() {
 
     @Test
     fun testN1QLSelectStarFromDefault() {
-        loadDocuments(100, testDatabase.getDefaultCollection())
+        loadDocuments(100, testDatabase.defaultCollection)
         verifyQuery(
             testDatabase.createQuery("SELECT * FROM _default"),
             100
@@ -3049,7 +3049,7 @@ class QueryTest : BaseQueryTest() {
 
     @Test
     fun testN1QLSelectStarFromUnderscore() {
-        loadDocuments(100, testDatabase.getDefaultCollection())
+        loadDocuments(100, testDatabase.defaultCollection)
         verifyQuery(
             testDatabase.createQuery("SELECT * FROM _"),
             100

--- a/couchbase-lite/src/commonTest/kotlin/kotbase/ReplicatorConfigurationTest.kt
+++ b/couchbase-lite/src/commonTest/kotlin/kotbase/ReplicatorConfigurationTest.kt
@@ -125,7 +125,7 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
         val replConfig = ReplicatorConfiguration(testDatabase, mockURLEndpoint)
         val collections = replConfig.collections
         assertEquals(1, collections.size)
-        assertTrue(collections.contains(testDatabase.getDefaultCollection()!!))
+        assertTrue(collections.contains(testDatabase.defaultCollection))
         assertEquals(testDatabase, replConfig.database)
     }
 
@@ -144,7 +144,7 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
     @Test
     fun testCreateConfigWithDatabaseB() {
         val collectionConfig = ReplicatorConfiguration(testDatabase, mockURLEndpoint)
-            .getCollectionConfiguration(testDatabase.getDefaultCollection()!!)
+            .getCollectionConfiguration(testDatabase.defaultCollection)
         assertNotNull(collectionConfig)
         assertNull(collectionConfig.conflictResolver)
         assertNull(collectionConfig.pushFilter)
@@ -169,7 +169,7 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
         val resolver = localResolver
         val replConfig = ReplicatorConfiguration(testDatabase, mockURLEndpoint).setConflictResolver(resolver)
         assertEquals(resolver, replConfig.conflictResolver)
-        val collectionConfig = replConfig.getCollectionConfiguration(testDatabase.getDefaultCollection()!!)
+        val collectionConfig = replConfig.getCollectionConfiguration(testDatabase.defaultCollection)
         assertNotNull(collectionConfig)
         assertEquals(resolver, collectionConfig.conflictResolver)
     }
@@ -202,13 +202,13 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
         val replConfig = ReplicatorConfiguration(testDatabase, mockURLEndpoint).setConflictResolver(resolver)
         assertEquals(
             replConfig.conflictResolver,
-            replConfig.getCollectionConfiguration(testDatabase.getDefaultCollection()!!)?.conflictResolver
+            replConfig.getCollectionConfiguration(testDatabase.defaultCollection)?.conflictResolver
         )
         val resolver2 = localResolver
         replConfig.conflictResolver = resolver2
         assertEquals(
             resolver2,
-            replConfig.getCollectionConfiguration(testDatabase.getDefaultCollection()!!)?.conflictResolver
+            replConfig.getCollectionConfiguration(testDatabase.defaultCollection)?.conflictResolver
         )
     }
 
@@ -237,7 +237,7 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
         assertContentEquals(arrayOf("CNBC", "ABC"), replConfig1.channels?.toTypedArray())
         assertContentEquals(arrayOf("doc1", "doc2"), replConfig1.documentIDs?.toTypedArray())
 
-        val collectionConfig1 = replConfig1.getCollectionConfiguration(testDatabase.getDefaultCollection()!!)
+        val collectionConfig1 = replConfig1.getCollectionConfiguration(testDatabase.defaultCollection)
         assertNotNull(collectionConfig1)
         assertEquals(pushFilter1, collectionConfig1.pushFilter)
         assertEquals(pullFilter1, collectionConfig1.pullFilter)
@@ -284,7 +284,7 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
         assertContentEquals(arrayOf("CNBC", "ABC"), replConfig1.channels?.toTypedArray())
         assertContentEquals(arrayOf("doc1", "doc2"), replConfig1.documentIDs?.toTypedArray())
 
-        val collectionConfig1 = replConfig1.getCollectionConfiguration(testDatabase.getDefaultCollection()!!)
+        val collectionConfig1 = replConfig1.getCollectionConfiguration(testDatabase.defaultCollection)
         assertNotNull(collectionConfig1)
         assertEquals(pushFilter1, collectionConfig1.pushFilter)
         assertEquals(pullFilter1, collectionConfig1.pullFilter)
@@ -303,7 +303,7 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
         assertContentEquals(arrayOf("CNBC", "ABC"), collectionConfig1.channels?.toTypedArray())
         assertContentEquals(arrayOf("doc1", "doc2"), collectionConfig1.documentIDs?.toTypedArray())
 
-        val collectionConfig2 = replConfig1.getCollectionConfiguration(testDatabase.getDefaultCollection()!!)
+        val collectionConfig2 = replConfig1.getCollectionConfiguration(testDatabase.defaultCollection)
         assertNotNull(collectionConfig2)
         assertEquals(pushFilter2, collectionConfig2.pushFilter)
         assertEquals(pullFilter2, collectionConfig2.pullFilter)
@@ -348,7 +348,7 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
         assertContentEquals(arrayOf("CNBC", "ABC"), replConfig1.channels?.toTypedArray())
         assertContentEquals(arrayOf("doc1", "doc2"), replConfig1.documentIDs?.toTypedArray())
 
-        val collectionConfig1 = replConfig1.getCollectionConfiguration(testDatabase.getDefaultCollection()!!)
+        val collectionConfig1 = replConfig1.getCollectionConfiguration(testDatabase.defaultCollection)
         assertNotNull(collectionConfig1)
         assertEquals(pushFilter1, collectionConfig1.pushFilter)
         assertEquals(pullFilter1, collectionConfig1.pullFilter)
@@ -362,14 +362,14 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
             .setPullFilter(pullFilter2)
             .setChannels(listOf("Peacock", "History"))
             .setDocumentIDs(listOf("doc3"))
-        replConfig1.addCollection(testDatabase.getDefaultCollection()!!, collectionConfig2)
+        replConfig1.addCollection(testDatabase.defaultCollection, collectionConfig2)
 
         assertEquals(pushFilter2, replConfig1.pushFilter)
         assertEquals(pullFilter2, replConfig1.pullFilter)
         assertContentEquals(arrayOf("Peacock", "History"), replConfig1.channels?.toTypedArray())
         assertContentEquals(arrayOf("doc3"), replConfig1.documentIDs?.toTypedArray())
 
-        val collectionConfig3 = replConfig1.getCollectionConfiguration(testDatabase.getDefaultCollection()!!)
+        val collectionConfig3 = replConfig1.getCollectionConfiguration(testDatabase.defaultCollection)
         assertNotNull(collectionConfig3)
         assertEquals(pushFilter2, collectionConfig3.pushFilter)
         assertEquals(pullFilter2, collectionConfig3.pullFilter)
@@ -658,7 +658,7 @@ class ReplicatorConfigurationTest : BaseReplicatorTest() {
     @Suppress("DEPRECATION")
     @Test
     fun testUpdateCollectionConfigB() {
-        val defaultCollection = testDatabase.getDefaultCollection()!!
+        val defaultCollection = testDatabase.defaultCollection
         val collectionA = testDatabase.createCollection("colA", "scopeA")
 
         val filter: ReplicationFilter = { _, _ -> true }

--- a/couchbase-lite/src/jvmCommonMain/kotlin/kotbase/Collection.jvmCommon.kt
+++ b/couchbase-lite/src/jvmCommonMain/kotlin/kotbase/Collection.jvmCommon.kt
@@ -146,9 +146,9 @@ internal constructor(
         }
     }
 
-    @Throws(CouchbaseLiteException::class)
-    public actual fun getIndexes(): Set<String> =
-        actual.indexes
+    @get:Throws(CouchbaseLiteException::class)
+    public actual val indexes: Set<String>
+        get() = actual.indexes
 
     @Throws(CouchbaseLiteException::class)
     public actual fun createIndex(name: String, config: IndexConfiguration) {

--- a/couchbase-lite/src/jvmCommonMain/kotlin/kotbase/DataSource.jvmCommon.kt
+++ b/couchbase-lite/src/jvmCommonMain/kotlin/kotbase/DataSource.jvmCommon.kt
@@ -35,7 +35,7 @@ private constructor(actual: CBLDataSource) : DelegatedClass<CBLDataSource>(actua
         @Suppress("DEPRECATION")
         @Deprecated(
             "Use DataSource.collection(Collection)",
-            ReplaceWith("collection(database.getDefaultCollection()!!)")
+            ReplaceWith("collection(database.defaultCollection)")
         )
         public actual fun database(database: Database): As =
             As(CBLDataSource.database(database.actual))

--- a/couchbase-lite/src/jvmCommonMain/kotlin/kotbase/Database.jvmCommon.kt
+++ b/couchbase-lite/src/jvmCommonMain/kotlin/kotbase/Database.jvmCommon.kt
@@ -89,9 +89,9 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
         actual.delete()
     }
 
-    @Throws(CouchbaseLiteException::class)
-    public actual fun getScopes(): Set<Scope> =
-        actual.scopes.asScopes(this)
+    @get:Throws(CouchbaseLiteException::class)
+    public actual val scopes: Set<Scope>
+        get () = actual.scopes.asScopes(this)
 
     @Throws(CouchbaseLiteException::class)
     public actual fun getScope(name: String): Scope? =

--- a/couchbase-lite/src/jvmCommonMain/kotlin/kotbase/Database.jvmCommon.kt
+++ b/couchbase-lite/src/jvmCommonMain/kotlin/kotbase/Database.jvmCommon.kt
@@ -360,9 +360,9 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
         "Use defaultCollection.indexes",
         ReplaceWith("defaultCollection.indexes")
     )
-    @Throws(CouchbaseLiteException::class)
-    public actual fun getIndexes(): List<String> =
-        actual.indexes
+    @get:Throws(CouchbaseLiteException::class)
+    public actual val indexes: List<String>
+        get() = actual.indexes
 
     @Suppress("DEPRECATION")
     @Deprecated(

--- a/couchbase-lite/src/jvmCommonMain/kotlin/kotbase/Database.jvmCommon.kt
+++ b/couchbase-lite/src/jvmCommonMain/kotlin/kotbase/Database.jvmCommon.kt
@@ -125,13 +125,10 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
     public actual fun getCollection(collectionName: String, scopeName: String?): Collection? =
         actual.getCollection(collectionName, scopeName)?.asCollection(this)
 
-    private val _defaultCollection: Collection by lazy {
+    @get:Throws(CouchbaseLiteException::class)
+    public actual val defaultCollection: Collection by lazy {
         actual.defaultCollection!!.asCollection(this)
     }
-
-    @Throws(CouchbaseLiteException::class)
-    public actual fun getDefaultCollection(): Collection =
-        _defaultCollection
 
     @Throws(CouchbaseLiteException::class)
     public actual fun deleteCollection(name: String) {
@@ -159,24 +156,24 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
 
     @Suppress("DEPRECATION")
     @Deprecated(
-        "Use getDefaultCollection().count",
-        ReplaceWith("getDefaultCollection()!!.count")
+        "Use defaultCollection.count",
+        ReplaceWith("defaultCollection.count")
     )
     public actual val count: Long
         get() = actual.count
 
     @Suppress("DEPRECATION")
     @Deprecated(
-        "Use getDefaultCollection().getDocument()",
-        ReplaceWith("getDefaultCollection()!!.getDocument(id)")
+        "Use defaultCollection.getDocument()",
+        ReplaceWith("defaultCollection.getDocument(id)")
     )
     public actual fun getDocument(id: String): Document? =
-        actual.getDocument(id)?.asDocument(getDefaultCollection())
+        actual.getDocument(id)?.asDocument(defaultCollection)
 
     @Suppress("DEPRECATION")
     @Deprecated(
-        "Use getDefaultCollection().save()",
-        ReplaceWith("getDefaultCollection().save(document)")
+        "Use defaultCollection.save()",
+        ReplaceWith("defaultCollection.save(document)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun save(document: MutableDocument) {
@@ -185,8 +182,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
 
     @Suppress("DEPRECATION")
     @Deprecated(
-        "Use getDefaultCollection().save()",
-        ReplaceWith("getDefaultCollection().save(document, concurrencyControl)")
+        "Use defaultCollection.save()",
+        ReplaceWith("defaultCollection.save(document, concurrencyControl)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun save(
@@ -197,17 +194,17 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
 
     @Suppress("DEPRECATION")
     @Deprecated(
-        "Use getDefaultCollection().save()",
-        ReplaceWith("getDefaultCollection().save(document, conflictHandler)")
+        "Use defaultCollection.save()",
+        ReplaceWith("defaultCollection.save(document, conflictHandler)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun save(document: MutableDocument, conflictHandler: ConflictHandler): Boolean =
-        actual.save(document.actual, conflictHandler.convert(getDefaultCollection()))
+        actual.save(document.actual, conflictHandler.convert(defaultCollection))
 
     @Suppress("DEPRECATION")
     @Deprecated(
-        "Use getDefaultCollection().delete()",
-        ReplaceWith("getDefaultCollection().delete(document)")
+        "Use defaultCollection.delete()",
+        ReplaceWith("defaultCollection.delete(document)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun delete(document: Document) {
@@ -216,8 +213,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
 
     @Suppress("DEPRECATION")
     @Deprecated(
-        "Use getDefaultCollection().delete()",
-        ReplaceWith("getDefaultCollection().delete(document, concurrencyControl)")
+        "Use defaultCollection.delete()",
+        ReplaceWith("defaultCollection.delete(document, concurrencyControl)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun delete(document: Document, concurrencyControl: ConcurrencyControl): Boolean =
@@ -225,8 +222,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
 
     @Suppress("DEPRECATION")
     @Deprecated(
-        "Use getDefaultCollection().purge()",
-        ReplaceWith("getDefaultCollection().purge(document)")
+        "Use defaultCollection.purge()",
+        ReplaceWith("defaultCollection.purge(document)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun purge(document: Document) {
@@ -235,8 +232,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
 
     @Suppress("DEPRECATION")
     @Deprecated(
-        "Use getDefaultCollection().purge()",
-        ReplaceWith("getDefaultCollection().purge(id)")
+        "Use defaultCollection.purge()",
+        ReplaceWith("defaultCollection.purge(id)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun purge(id: String) {
@@ -245,8 +242,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
 
     @Suppress("DEPRECATION")
     @Deprecated(
-        "Use getDefaultCollection().setDocumentExpiration()",
-        ReplaceWith("getDefaultCollection().setDocumentExpiration(id, expiration)")
+        "Use defaultCollection.setDocumentExpiration()",
+        ReplaceWith("defaultCollection.setDocumentExpiration(id, expiration)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun setDocumentExpiration(id: String, expiration: Instant?) {
@@ -255,8 +252,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
 
     @Suppress("DEPRECATION")
     @Deprecated(
-        "Use getDefaultCollection().getDocumentExpiration()",
-        ReplaceWith("getDefaultCollection().getDocumentExpiration(id)")
+        "Use defaultCollection.getDocumentExpiration()",
+        ReplaceWith("defaultCollection.getDocumentExpiration(id)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun getDocumentExpiration(id: String): Instant? =
@@ -264,8 +261,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
 
     @Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
     @Deprecated(
-        "Use getDefaultCollection().addChangeListener()",
-        ReplaceWith("getDefaultCollection().addChangeListener(listener)")
+        "Use defaultCollection.addChangeListener()",
+        ReplaceWith("defaultCollection.addChangeListener(listener)")
     )
     public actual fun addChangeListener(listener: DatabaseChangeListener): ListenerToken =
         DelegatedListenerToken(actual.addChangeListener(listener.convert(this)))
@@ -273,8 +270,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
     @Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
     @OptIn(ExperimentalStdlibApi::class)
     @Deprecated(
-        "Use getDefaultCollection().addChangeListener()",
-        ReplaceWith("getDefaultCollection().addChangeListener(context, listener)")
+        "Use defaultCollection.addChangeListener()",
+        ReplaceWith("defaultCollection.addChangeListener(context, listener)")
     )
     public actual fun addChangeListener(
         context: CoroutineContext,
@@ -288,8 +285,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
     @Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
     @OptIn(ExperimentalStdlibApi::class)
     @Deprecated(
-        "Use getDefaultCollection().addChangeListener()",
-        ReplaceWith("getDefaultCollection().addChangeListener(scope, listener)")
+        "Use defaultCollection.addChangeListener()",
+        ReplaceWith("defaultCollection.addChangeListener(scope, listener)")
     )
     public actual fun addChangeListener(scope: CoroutineScope, listener: DatabaseChangeSuspendListener) {
         val token = actual.addChangeListener(
@@ -303,17 +300,17 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
 
     @Suppress("DEPRECATION")
     @Deprecated(
-        "Use getDefaultCollection().addDocumentChangeListener()",
-        ReplaceWith("getDefaultCollection().addDocumentChangeListener(id, listener)")
+        "Use defaultCollection.addDocumentChangeListener()",
+        ReplaceWith("defaultCollection.addDocumentChangeListener(id, listener)")
     )
     public actual fun addDocumentChangeListener(id: String, listener: DocumentChangeListener): ListenerToken =
-        DelegatedListenerToken(actual.addDocumentChangeListener(id, listener.convert(getDefaultCollection())))
+        DelegatedListenerToken(actual.addDocumentChangeListener(id, listener.convert(defaultCollection)))
 
     @Suppress("DEPRECATION")
     @OptIn(ExperimentalStdlibApi::class)
     @Deprecated(
-        "Use getDefaultCollection().addDocumentChangeListener()",
-        ReplaceWith("getDefaultCollection().addDocumentChangeListener(id, context, listener)")
+        "Use defaultCollection.addDocumentChangeListener()",
+        ReplaceWith("defaultCollection.addDocumentChangeListener(id, context, listener)")
     )
     public actual fun addDocumentChangeListener(
         id: String,
@@ -324,7 +321,7 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
         val token = actual.addDocumentChangeListener(
             id,
             context[CoroutineDispatcher]?.asExecutor(),
-            listener.convert(getDefaultCollection(), scope)
+            listener.convert(defaultCollection, scope)
         )
         return SuspendListenerToken(scope, token)
     }
@@ -332,8 +329,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
     @Suppress("DEPRECATION")
     @OptIn(ExperimentalStdlibApi::class)
     @Deprecated(
-        "Use getDefaultCollection().addDocumentChangeListener()",
-        ReplaceWith("getDefaultCollection().addDocumentChangeListener(id, scope, listener)")
+        "Use defaultCollection.addDocumentChangeListener()",
+        ReplaceWith("defaultCollection.addDocumentChangeListener(id, scope, listener)")
     )
     public actual fun addDocumentChangeListener(
         id: String,
@@ -343,7 +340,7 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
         val token = actual.addDocumentChangeListener(
             id,
             scope.coroutineContext[CoroutineDispatcher]?.asExecutor(),
-            listener.convert(getDefaultCollection(), scope)
+            listener.convert(defaultCollection, scope)
         )
         scope.coroutineContext[Job]?.invokeOnCompletion {
             token.remove()
@@ -360,8 +357,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
 
     @Suppress("DEPRECATION")
     @Deprecated(
-        "Use getDefaultCollection().indexes",
-        ReplaceWith("getDefaultCollection().indexes")
+        "Use defaultCollection.indexes",
+        ReplaceWith("defaultCollection.indexes")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun getIndexes(): List<String> =
@@ -369,8 +366,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
 
     @Suppress("DEPRECATION")
     @Deprecated(
-        "Use getDefaultCollection().createIndex()",
-        ReplaceWith("getDefaultCollection().createIndex(name, index)")
+        "Use defaultCollection.createIndex()",
+        ReplaceWith("defaultCollection.createIndex(name, index)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun createIndex(name: String, index: Index) {
@@ -379,8 +376,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
 
     @Suppress("DEPRECATION")
     @Deprecated(
-        "Use getDefaultCollection().createIndex()",
-        ReplaceWith("getDefaultCollection().createIndex(name, config)")
+        "Use defaultCollection.createIndex()",
+        ReplaceWith("defaultCollection.createIndex(name, config)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun createIndex(name: String, config: IndexConfiguration) {
@@ -389,8 +386,8 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
 
     @Suppress("DEPRECATION")
     @Deprecated(
-        "Use getDefaultCollection().deleteIndex()",
-        ReplaceWith("getDefaultCollection().deleteIndex(name)")
+        "Use defaultCollection.deleteIndex()",
+        ReplaceWith("defaultCollection.deleteIndex(name)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun deleteIndex(name: String) {

--- a/couchbase-lite/src/jvmCommonMain/kotlin/kotbase/Database.jvmCommon.kt
+++ b/couchbase-lite/src/jvmCommonMain/kotlin/kotbase/Database.jvmCommon.kt
@@ -97,9 +97,9 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
     public actual fun getScope(name: String): Scope? =
         actual.getScope(name)?.asScope(this)
 
-    @Throws(CouchbaseLiteException::class)
-    public actual fun getDefaultScope(): Scope =
-        Scope(actual.defaultScope, this)
+    @get:Throws(CouchbaseLiteException::class)
+    public actual val defaultScope: Scope
+        get() = Scope(actual.defaultScope, this)
 
     @Throws(CouchbaseLiteException::class)
     public actual fun createCollection(name: String): Collection =

--- a/couchbase-lite/src/jvmCommonMain/kotlin/kotbase/Database.jvmCommon.kt
+++ b/couchbase-lite/src/jvmCommonMain/kotlin/kotbase/Database.jvmCommon.kt
@@ -109,9 +109,9 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
     public actual fun createCollection(collectionName: String, scopeName: String?): Collection =
         Collection(actual.createCollection(collectionName, scopeName), this)
 
-    @Throws(CouchbaseLiteException::class)
-    public actual fun getCollections(): Set<Collection> =
-        actual.collections.asCollections(this)
+    @get:Throws(CouchbaseLiteException::class)
+    public actual val collections: Set<Collection>
+        get() = actual.collections.asCollections(this)
 
     @Throws(CouchbaseLiteException::class)
     public actual fun getCollections(scopeName: String?): Set<Collection> =

--- a/couchbase-lite/src/jvmCommonMain/kotlin/kotbase/Replicator.jvmCommon.kt
+++ b/couchbase-lite/src/jvmCommonMain/kotlin/kotbase/Replicator.jvmCommon.kt
@@ -70,9 +70,9 @@ internal constructor(
         "Use getPendingDocumentIds(Collection)",
         ReplaceWith("getPendingDocumentIds(config.database.defaultCollection)")
     )
-    @Throws(CouchbaseLiteException::class)
-    public actual fun getPendingDocumentIds(): Set<String> =
-        actual.pendingDocumentIds
+    @get:Throws(CouchbaseLiteException::class)
+    public actual val pendingDocumentIds: Set<String>
+        get() = actual.pendingDocumentIds
 
     @Throws(CouchbaseLiteException::class)
     public actual fun getPendingDocumentIds(collection: Collection): Set<String> =

--- a/couchbase-lite/src/jvmCommonMain/kotlin/kotbase/Replicator.jvmCommon.kt
+++ b/couchbase-lite/src/jvmCommonMain/kotlin/kotbase/Replicator.jvmCommon.kt
@@ -68,7 +68,7 @@ internal constructor(
     @Suppress("DEPRECATION")
     @Deprecated(
         "Use getPendingDocumentIds(Collection)",
-        ReplaceWith("getPendingDocumentIds(config.database.getDefaultCollection()!!)")
+        ReplaceWith("getPendingDocumentIds(config.database.defaultCollection)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun getPendingDocumentIds(): Set<String> =
@@ -81,7 +81,7 @@ internal constructor(
     @Suppress("DEPRECATION")
     @Deprecated(
         "Use isDocumentPending(String, Collection)",
-        ReplaceWith("isDocumentPending(docId, config.database.getDefaultCollection()!!)")
+        ReplaceWith("isDocumentPending(docId, config.database.defaultCollection)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun isDocumentPending(docId: String): Boolean =

--- a/couchbase-lite/src/jvmCommonMain/kotlin/kotbase/ReplicatorConfiguration.jvmCommon.kt
+++ b/couchbase-lite/src/jvmCommonMain/kotlin/kotbase/ReplicatorConfiguration.jvmCommon.kt
@@ -39,7 +39,7 @@ private constructor(
         target,
         database
     ) {
-        addCollection(database.getDefaultCollection(), null)
+        addCollection(database.defaultCollection, null)
     }
 
     public actual constructor(target: Endpoint) : this(
@@ -288,23 +288,19 @@ private constructor(
         }
 
     @Suppress("DEPRECATION")
-    private val defaultCollection: Collection by lazy {
-        database.getDefaultCollection()
-            ?: throw IllegalArgumentException("Cannot use legacy parameters when there is no default collection")
-    }
-
     private fun getDefaultCollectionConfiguration(): CollectionConfiguration {
-        return collectionConfigurations[defaultCollection]
+        return collectionConfigurations[database.defaultCollection]
             ?: throw IllegalArgumentException(
                 "Cannot use legacy parameters when the default collection has no configuration"
             )
     }
 
+    @Suppress("DEPRECATION")
     private fun updateDefaultConfig(updater: CollectionConfiguration.() -> Unit) {
         val config = getDefaultCollectionConfiguration()
         val updated = CollectionConfiguration(config)
         updated.updater()
-        addCollection(defaultCollection, updated)
+        addCollection(database.defaultCollection, updated)
     }
 
     public actual companion object

--- a/couchbase-lite/src/jvmCommonMain/kotlin/kotbase/ReplicatorConfiguration.jvmCommon.kt
+++ b/couchbase-lite/src/jvmCommonMain/kotlin/kotbase/ReplicatorConfiguration.jvmCommon.kt
@@ -32,7 +32,7 @@ private constructor(
     @Suppress("DEPRECATION")
     @Deprecated(
         "Use ReplicatorConfiguration(Endpoint)",
-        ReplaceWith("ReplicatorConfiguration(target)")
+        ReplaceWith("ReplicatorConfiguration(target).addCollection(database.defaultCollection, null)")
     )
     public actual constructor(database: Database, target: Endpoint) : this(
         CBLReplicatorConfiguration(database.actual, target.actual),

--- a/couchbase-lite/src/jvmCommonMain/kotlin/kotbase/Scope.jvmCommon.kt
+++ b/couchbase-lite/src/jvmCommonMain/kotlin/kotbase/Scope.jvmCommon.kt
@@ -27,9 +27,9 @@ internal constructor(
     public actual val name: String
         get() = actual.name
 
-    @Throws(CouchbaseLiteException::class)
-    public actual fun getCollections(): Set<Collection> =
-        actual.collections.asCollections(database)
+    @get:Throws(CouchbaseLiteException::class)
+    public actual val collections: Set<Collection>
+        get() = actual.collections.asCollections(database)
 
     @Throws(CouchbaseLiteException::class)
     public actual fun getCollection(collectionName: String): Collection? =

--- a/couchbase-lite/src/linuxMingwMain/kotlin/kotbase/Collection.linuxMingw.kt
+++ b/couchbase-lite/src/linuxMingwMain/kotlin/kotbase/Collection.linuxMingw.kt
@@ -322,16 +322,18 @@ internal constructor(
         }
     }
 
-    @Throws(CouchbaseLiteException::class)
-    public actual fun getIndexes(): Set<String> {
-        return wrapCBLError { error ->
-            val names = CBLCollection_GetIndexNames(actual, error)
-            @Suppress("UNCHECKED_CAST")
-            (names?.toList(null) as List<String>?)?.also {
-                FLMutableArray_Release(names)
-            }?.toSet() ?: emptySet()
+    @Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT") // https://youtrack.jetbrains.com/issue/KT-63047
+    //@get:Throws(CouchbaseLiteException::class)
+    public actual val indexes: Set<String>
+        get() {
+            return wrapCBLError { error ->
+                val names = CBLCollection_GetIndexNames(actual, error)
+                @Suppress("UNCHECKED_CAST")
+                (names?.toList(null) as List<String>?)?.also {
+                    FLMutableArray_Release(names)
+                }?.toSet() ?: emptySet()
+            }
         }
-    }
 
     @Throws(CouchbaseLiteException::class)
     public actual fun createIndex(name: String, config: IndexConfiguration) {

--- a/couchbase-lite/src/linuxMingwMain/kotlin/kotbase/DataSource.linuxMingw.kt
+++ b/couchbase-lite/src/linuxMingwMain/kotlin/kotbase/DataSource.linuxMingw.kt
@@ -43,10 +43,10 @@ private constructor(
 
         @Deprecated(
             "Use DataSource.collection(Collection)",
-            ReplaceWith("collection(database.getDefaultCollection()!!)")
+            ReplaceWith("collection(database.defaultCollection)")
         )
         public actual fun database(database: Database): As =
-            As(database.getDefaultCollection()).apply {
+            As(database.defaultCollection).apply {
                 `as`(database.name)
             }
 

--- a/couchbase-lite/src/linuxMingwMain/kotlin/kotbase/Database.linuxMingw.kt
+++ b/couchbase-lite/src/linuxMingwMain/kotlin/kotbase/Database.linuxMingw.kt
@@ -240,15 +240,13 @@ private constructor(
         }?.asCollection(this)
     }
 
-    private val _defaultCollection: Collection by lazy {
+    @Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT") // https://youtrack.jetbrains.com/issue/KT-63047
+    //@get:Throws(CouchbaseLiteException::class)
+    public actual val defaultCollection: Collection by lazy {
         wrapCBLError { error ->
             CBLDatabase_DefaultCollection(actual, error)
         }!!.asCollection(this)
     }
-
-    @Throws(CouchbaseLiteException::class)
-    public actual fun getDefaultCollection(): Collection =
-        _defaultCollection
 
     @Throws(CouchbaseLiteException::class)
     public actual fun deleteCollection(name: String) {
@@ -316,15 +314,15 @@ private constructor(
     }
 
     @Deprecated(
-        "Use getDefaultCollection().count",
-        ReplaceWith("getDefaultCollection().count")
+        "Use defaultCollection.count",
+        ReplaceWith("defaultCollection.count")
     )
     public actual val count: Long
         get() = CBLDatabase_Count(actual).toLong()
 
     @Deprecated(
-        "Use getDefaultCollection().getDocument()",
-        ReplaceWith("getDefaultCollection().getDocument(id)")
+        "Use defaultCollection.getDocument()",
+        ReplaceWith("defaultCollection.getDocument(id)")
     )
     public actual fun getDocument(id: String): Document? {
         return mustBeOpen {
@@ -337,8 +335,8 @@ private constructor(
     }
 
     @Deprecated(
-        "Use getDefaultCollection().save()",
-        ReplaceWith("getDefaultCollection().save(document)")
+        "Use defaultCollection.save()",
+        ReplaceWith("defaultCollection.save(document)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun save(document: MutableDocument) {
@@ -352,8 +350,8 @@ private constructor(
     }
 
     @Deprecated(
-        "Use getDefaultCollection().save()",
-        ReplaceWith("getDefaultCollection().save(document, concurrencyControl)")
+        "Use defaultCollection.save()",
+        ReplaceWith("defaultCollection.save(document, concurrencyControl)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun save(
@@ -387,8 +385,8 @@ private constructor(
     private var conflictHandler: StableRef<ConflictHandlerWrapper>? = null
 
     @Deprecated(
-        "Use getDefaultCollection().save()",
-        ReplaceWith("getDefaultCollection().save(document, conflictHandler)")
+        "Use defaultCollection.save()",
+        ReplaceWith("defaultCollection.save(document, conflictHandler)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun save(document: MutableDocument, conflictHandler: ConflictHandler): Boolean {
@@ -429,8 +427,8 @@ private constructor(
     }
 
     @Deprecated(
-        "Use getDefaultCollection().delete()",
-        ReplaceWith("getDefaultCollection().delete(document)")
+        "Use defaultCollection.delete()",
+        ReplaceWith("defaultCollection.delete(document)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun delete(document: Document) {
@@ -443,8 +441,8 @@ private constructor(
     }
 
     @Deprecated(
-        "Use getDefaultCollection().delete()",
-        ReplaceWith("getDefaultCollection().delete(document, concurrencyControl)")
+        "Use defaultCollection.delete()",
+        ReplaceWith("defaultCollection.delete(document, concurrencyControl)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun delete(document: Document, concurrencyControl: ConcurrencyControl): Boolean {
@@ -472,8 +470,8 @@ private constructor(
     }
 
     @Deprecated(
-        "Use getDefaultCollection().purge()",
-        ReplaceWith("getDefaultCollection().purge(document)")
+        "Use defaultCollection.purge()",
+        ReplaceWith("defaultCollection.purge(document)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun purge(document: Document) {
@@ -492,8 +490,8 @@ private constructor(
     }
 
     @Deprecated(
-        "Use getDefaultCollection().purge()",
-        ReplaceWith("getDefaultCollection().purge(id)")
+        "Use defaultCollection.purge()",
+        ReplaceWith("defaultCollection.purge(id)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun purge(id: String) {
@@ -507,8 +505,8 @@ private constructor(
     }
 
     @Deprecated(
-        "Use getDefaultCollection().setDocumentExpiration()",
-        ReplaceWith("getDefaultCollection().setDocumentExpiration(id, expiration)")
+        "Use defaultCollection.setDocumentExpiration()",
+        ReplaceWith("defaultCollection.setDocumentExpiration(id, expiration)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun setDocumentExpiration(id: String, expiration: Instant?) {
@@ -527,8 +525,8 @@ private constructor(
     }
 
     @Deprecated(
-        "Use getDefaultCollection().getDocumentExpiration()",
-        ReplaceWith("getDefaultCollection().getDocumentExpiration(id)")
+        "Use defaultCollection.getDocumentExpiration()",
+        ReplaceWith("defaultCollection.getDocumentExpiration(id)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun getDocumentExpiration(id: String): Instant? {
@@ -543,8 +541,8 @@ private constructor(
 
     @Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
     @Deprecated(
-        "Use getDefaultCollection().addChangeListener()",
-        ReplaceWith("getDefaultCollection().addChangeListener(listener)")
+        "Use defaultCollection.addChangeListener()",
+        ReplaceWith("defaultCollection.addChangeListener(listener)")
     )
     public actual fun addChangeListener(listener: DatabaseChangeListener): ListenerToken {
         return mustBeOpen {
@@ -555,8 +553,8 @@ private constructor(
 
     @Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
     @Deprecated(
-        "Use getDefaultCollection().addChangeListener()",
-        ReplaceWith("getDefaultCollection().addChangeListener(context, listener)")
+        "Use defaultCollection.addChangeListener()",
+        ReplaceWith("defaultCollection.addChangeListener(context, listener)")
     )
     public actual fun addChangeListener(
         context: CoroutineContext,
@@ -572,8 +570,8 @@ private constructor(
 
     @Suppress("DEPRECATION", "TYPEALIAS_EXPANSION_DEPRECATION")
     @Deprecated(
-        "Use getDefaultCollection().addChangeListener()",
-        ReplaceWith("getDefaultCollection().addChangeListener(scope, listener)")
+        "Use defaultCollection.addChangeListener()",
+        ReplaceWith("defaultCollection.addChangeListener(scope, listener)")
     )
     public actual fun addChangeListener(scope: CoroutineScope, listener: DatabaseChangeSuspendListener) {
         mustBeOpen {
@@ -607,8 +605,8 @@ private constructor(
     }
 
     @Deprecated(
-        "Use getDefaultCollection().addDocumentChangeListener()",
-        ReplaceWith("getDefaultCollection().addDocumentChangeListener(id, listener)")
+        "Use defaultCollection.addDocumentChangeListener()",
+        ReplaceWith("defaultCollection.addDocumentChangeListener(id, listener)")
     )
     public actual fun addDocumentChangeListener(id: String, listener: DocumentChangeListener): ListenerToken {
         return mustBeOpen {
@@ -618,8 +616,8 @@ private constructor(
     }
 
     @Deprecated(
-        "Use getDefaultCollection().addDocumentChangeListener()",
-        ReplaceWith("getDefaultCollection().addDocumentChangeListener(id, context, listener)")
+        "Use defaultCollection.addDocumentChangeListener()",
+        ReplaceWith("defaultCollection.addDocumentChangeListener(id, context, listener)")
     )
     public actual fun addDocumentChangeListener(
         id: String,
@@ -635,8 +633,8 @@ private constructor(
     }
 
     @Deprecated(
-        "Use getDefaultCollection().addDocumentChangeListener()",
-        ReplaceWith("getDefaultCollection().addDocumentChangeListener(id, scope, listener)")
+        "Use defaultCollection.addDocumentChangeListener()",
+        ReplaceWith("defaultCollection.addDocumentChangeListener(id, scope, listener)")
     )
     public actual fun addDocumentChangeListener(
         id: String,
@@ -669,7 +667,7 @@ private constructor(
     private fun nativeDocumentChangeListener(): CBLDocumentChangeListener {
         return staticCFunction { ref, _, docId ->
             with(ref.to<DocumentChangeListenerHolder>()) {
-                val change = DocumentChange(database.getDefaultCollection(), docId.toKString()!!)
+                val change = DocumentChange(database.defaultCollection, docId.toKString()!!)
                 when (this) {
                     is DocumentChangeDefaultListenerHolder -> listener(change)
                     is DocumentChangeSuspendListenerHolder -> scope.launch {
@@ -689,8 +687,8 @@ private constructor(
     }
 
     @Deprecated(
-        "Use getDefaultCollection().indexes",
-        ReplaceWith("getDefaultCollection().indexes")
+        "Use defaultCollection.indexes",
+        ReplaceWith("defaultCollection.indexes")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun getIndexes(): List<String> {
@@ -704,8 +702,8 @@ private constructor(
     }
 
     @Deprecated(
-        "Use getDefaultCollection().createIndex()",
-        ReplaceWith("getDefaultCollection().createIndex(name, index)")
+        "Use defaultCollection.createIndex()",
+        ReplaceWith("defaultCollection.createIndex(name, index)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun createIndex(name: String, index: Index) {
@@ -734,8 +732,8 @@ private constructor(
     }
 
     @Deprecated(
-        "Use getDefaultCollection().createIndex()",
-        ReplaceWith("getDefaultCollection().createIndex(name, config)")
+        "Use defaultCollection.createIndex()",
+        ReplaceWith("defaultCollection.createIndex(name, config)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun createIndex(name: String, config: IndexConfiguration) {
@@ -763,8 +761,8 @@ private constructor(
     }
 
     @Deprecated(
-        "Use getDefaultCollection().deleteIndex()",
-        ReplaceWith("getDefaultCollection().deleteIndex(name)")
+        "Use defaultCollection.deleteIndex()",
+        ReplaceWith("defaultCollection.deleteIndex(name)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun deleteIndex(name: String) {

--- a/couchbase-lite/src/linuxMingwMain/kotlin/kotbase/Database.linuxMingw.kt
+++ b/couchbase-lite/src/linuxMingwMain/kotlin/kotbase/Database.linuxMingw.kt
@@ -695,16 +695,18 @@ private constructor(
         "Use defaultCollection.indexes",
         ReplaceWith("defaultCollection.indexes")
     )
-    @Throws(CouchbaseLiteException::class)
-    public actual fun getIndexes(): List<String> {
-        return mustBeOpen {
-            val names = CBLDatabase_GetIndexNames(actual)
-            @Suppress("UNCHECKED_CAST")
-            (names?.toList(null) as List<String>?)?.also {
-                FLArray_Release(names)
-            } ?: emptyList()
+    @Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT") // https://youtrack.jetbrains.com/issue/KT-63047
+    //@get:Throws(CouchbaseLiteException::class)
+    public actual val indexes: List<String>
+        get() {
+            return mustBeOpen {
+                val names = CBLDatabase_GetIndexNames(actual)
+                @Suppress("UNCHECKED_CAST")
+                (names?.toList(null) as List<String>?)?.also {
+                    FLArray_Release(names)
+                } ?: emptyList()
+            }
         }
-    }
 
     @Deprecated(
         "Use defaultCollection.createIndex()",

--- a/couchbase-lite/src/linuxMingwMain/kotlin/kotbase/Database.linuxMingw.kt
+++ b/couchbase-lite/src/linuxMingwMain/kotlin/kotbase/Database.linuxMingw.kt
@@ -175,16 +175,18 @@ private constructor(
         }?.asScope(this)
     }
 
-    @Throws(CouchbaseLiteException::class)
-    public actual fun getDefaultScope(): Scope {
-        return wrapCBLError { error ->
-            CBLDatabase_DefaultScope(actual, error)
-        }!!.asScope(this)
-    }
+    @Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT") // https://youtrack.jetbrains.com/issue/KT-63047
+    //@get:Throws(CouchbaseLiteException::class)
+    public actual val defaultScope: Scope
+        get() {
+            return wrapCBLError { error ->
+                CBLDatabase_DefaultScope(actual, error)
+            }!!.asScope(this)
+        }
 
     @Throws(CouchbaseLiteException::class)
     public actual fun createCollection(name: String): Collection =
-        createCollection(name, getDefaultScope().name)
+        createCollection(name, defaultScope.name)
 
     @Throws(CouchbaseLiteException::class)
     public actual fun createCollection(collectionName: String, scopeName: String?): Collection {
@@ -202,7 +204,7 @@ private constructor(
 
     @Throws(CouchbaseLiteException::class)
     public actual fun getCollections(): Set<Collection> =
-        getCollections(getDefaultScope().name)
+        getCollections(defaultScope.name)
 
     @Throws(CouchbaseLiteException::class)
     public actual fun getCollections(scopeName: String?): Set<Collection> {
@@ -226,7 +228,7 @@ private constructor(
 
     @Throws(CouchbaseLiteException::class)
     public actual fun getCollection(name: String): Collection? =
-        getCollection(name, getDefaultScope().name)
+        getCollection(name, defaultScope.name)
 
     @Throws(CouchbaseLiteException::class)
     public actual fun getCollection(collectionName: String, scopeName: String?): Collection? {
@@ -252,7 +254,7 @@ private constructor(
 
     @Throws(CouchbaseLiteException::class)
     public actual fun deleteCollection(name: String) {
-        deleteCollection(name, getDefaultScope().name)
+        deleteCollection(name, defaultScope.name)
     }
 
     @Throws(CouchbaseLiteException::class)

--- a/couchbase-lite/src/linuxMingwMain/kotlin/kotbase/Database.linuxMingw.kt
+++ b/couchbase-lite/src/linuxMingwMain/kotlin/kotbase/Database.linuxMingw.kt
@@ -147,22 +147,24 @@ private constructor(
         }
     }
 
-    @Throws(CouchbaseLiteException::class)
-    public actual fun getScopes(): Set<Scope> {
-        val names = wrapCBLError { error ->
-            CBLDatabase_ScopeNames(actual, error)
-        }
-        return buildSet {
-            memScoped {
-                names?.iterator(this)?.forEach {
-                    wrapCBLError { error ->
-                        CBLDatabase_Scope(actual, FLValue_AsString(it), error)
-                    }?.asScope(this@Database)?.let(::add)
-                }
+    @Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT") // https://youtrack.jetbrains.com/issue/KT-63047
+    //@get:Throws(CouchbaseLiteException::class)
+    public actual val scopes: Set<Scope>
+        get() {
+            val names = wrapCBLError { error ->
+                CBLDatabase_ScopeNames(actual, error)
             }
-            FLMutableArray_Release(names)
+            return buildSet {
+                memScoped {
+                    names?.iterator(this)?.forEach {
+                        wrapCBLError { error ->
+                            CBLDatabase_Scope(actual, FLValue_AsString(it), error)
+                        }?.asScope(this@Database)?.let(::add)
+                    }
+                }
+                FLMutableArray_Release(names)
+            }
         }
-    }
 
     @Throws(CouchbaseLiteException::class)
     public actual fun getScope(name: String): Scope? {

--- a/couchbase-lite/src/linuxMingwMain/kotlin/kotbase/Database.linuxMingw.kt
+++ b/couchbase-lite/src/linuxMingwMain/kotlin/kotbase/Database.linuxMingw.kt
@@ -202,9 +202,10 @@ private constructor(
         }!!.asCollection(this)
     }
 
-    @Throws(CouchbaseLiteException::class)
-    public actual fun getCollections(): Set<Collection> =
-        getCollections(defaultScope.name)
+    @Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT") // https://youtrack.jetbrains.com/issue/KT-63047
+    //@get:Throws(CouchbaseLiteException::class)
+    public actual val collections: Set<Collection>
+        get() = getCollections(defaultScope.name)
 
     @Throws(CouchbaseLiteException::class)
     public actual fun getCollections(scopeName: String?): Set<Collection> {

--- a/couchbase-lite/src/linuxMingwMain/kotlin/kotbase/Replicator.linuxMingw.kt
+++ b/couchbase-lite/src/linuxMingwMain/kotlin/kotbase/Replicator.linuxMingw.kt
@@ -106,7 +106,7 @@ private constructor(
     @Suppress("DEPRECATION")
     @Deprecated(
         "Use getPendingDocumentIds(Collection)",
-        ReplaceWith("getPendingDocumentIds(config.database.getDefaultCollection()!!)")
+        ReplaceWith("getPendingDocumentIds(config.database.defaultCollection)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun getPendingDocumentIds(): Set<String> {
@@ -135,7 +135,7 @@ private constructor(
 
     @Deprecated(
         "Use isDocumentPending(String, Collection)",
-        ReplaceWith("isDocumentPending(docId, config.database.getDefaultCollection())")
+        ReplaceWith("isDocumentPending(docId, config.database.defaultCollection)")
     )
     @Throws(CouchbaseLiteException::class)
     public actual fun isDocumentPending(docId: String): Boolean {

--- a/couchbase-lite/src/linuxMingwMain/kotlin/kotbase/Replicator.linuxMingw.kt
+++ b/couchbase-lite/src/linuxMingwMain/kotlin/kotbase/Replicator.linuxMingw.kt
@@ -103,22 +103,23 @@ private constructor(
         }
     }
 
-    @Suppress("DEPRECATION")
     @Deprecated(
         "Use getPendingDocumentIds(Collection)",
         ReplaceWith("getPendingDocumentIds(config.database.defaultCollection)")
     )
-    @Throws(CouchbaseLiteException::class)
-    public actual fun getPendingDocumentIds(): Set<String> {
-        checkPullOnlyPendingDocIds()
-        config.database.mustBeOpen()
-        return wrapCBLError { error ->
-            val dict = CBLReplicator_PendingDocumentIDs(actual, error)
-            dict?.keys()?.also {
-                FLDict_Release(dict)
-            }?.toSet() ?: emptySet()
+    @Suppress("DEPRECATION", "ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT") // https://youtrack.jetbrains.com/issue/KT-63047
+    //@get:Throws(CouchbaseLiteException::class)
+    public actual val pendingDocumentIds: Set<String>
+        get() {
+            checkPullOnlyPendingDocIds()
+            config.database.mustBeOpen()
+            return wrapCBLError { error ->
+                val dict = CBLReplicator_PendingDocumentIDs(actual, error)
+                dict?.keys()?.also {
+                    FLDict_Release(dict)
+                }?.toSet() ?: emptySet()
+            }
         }
-    }
 
     @Suppress("DEPRECATION")
     @Throws(CouchbaseLiteException::class)

--- a/couchbase-lite/src/linuxMingwMain/kotlin/kotbase/ReplicatorConfiguration.linuxMingw.kt
+++ b/couchbase-lite/src/linuxMingwMain/kotlin/kotbase/ReplicatorConfiguration.linuxMingw.kt
@@ -36,7 +36,7 @@ private constructor(
         ReplaceWith("ReplicatorConfiguration(target)")
     )
     public actual constructor(database: Database, target: Endpoint) : this(target, database) {
-        addCollection(database.getDefaultCollection(), null)
+        addCollection(database.defaultCollection, null)
     }
 
     public actual constructor(target: Endpoint) : this(target, null)
@@ -293,7 +293,7 @@ private constructor(
 
     @Suppress("DEPRECATION")
     private val defaultCollection: Collection by lazy {
-        database.getDefaultCollection()
+        database.defaultCollection
             ?: throw IllegalArgumentException("Cannot use legacy parameters when there is no default collection")
     }
 

--- a/couchbase-lite/src/linuxMingwMain/kotlin/kotbase/ReplicatorConfiguration.linuxMingw.kt
+++ b/couchbase-lite/src/linuxMingwMain/kotlin/kotbase/ReplicatorConfiguration.linuxMingw.kt
@@ -292,22 +292,18 @@ private constructor(
         }
 
     @Suppress("DEPRECATION")
-    private val defaultCollection: Collection by lazy {
-        database.defaultCollection
-            ?: throw IllegalArgumentException("Cannot use legacy parameters when there is no default collection")
-    }
-
     private fun getDefaultCollectionConfiguration(): CollectionConfiguration =
-        collectionConfigurations[defaultCollection]
+        collectionConfigurations[database.defaultCollection]
             ?: throw IllegalArgumentException(
                 "Cannot use legacy parameters when the default collection has no configuration"
             )
 
+    @Suppress("DEPRECATION")
     private fun updateDefaultConfig(updater: CollectionConfiguration.() -> Unit) {
         val config = getDefaultCollectionConfiguration()
         val updated = CollectionConfiguration(config)
         updated.updater()
-        addCollection(defaultCollection, updated)
+        addCollection(database.defaultCollection, updated)
     }
 
     public override fun toString(): String {

--- a/couchbase-lite/src/linuxMingwMain/kotlin/kotbase/ReplicatorConfiguration.linuxMingw.kt
+++ b/couchbase-lite/src/linuxMingwMain/kotlin/kotbase/ReplicatorConfiguration.linuxMingw.kt
@@ -33,7 +33,7 @@ private constructor(
 
     @Deprecated(
         "Use ReplicatorConfiguration(Endpoint)",
-        ReplaceWith("ReplicatorConfiguration(target)")
+        ReplaceWith("ReplicatorConfiguration(target).addCollection(database.defaultCollection, null)")
     )
     public actual constructor(database: Database, target: Endpoint) : this(target, database) {
         addCollection(database.defaultCollection, null)

--- a/couchbase-lite/src/linuxMingwMain/kotlin/kotbase/Scope.linuxMingw.kt
+++ b/couchbase-lite/src/linuxMingwMain/kotlin/kotbase/Scope.linuxMingw.kt
@@ -41,22 +41,24 @@ internal constructor(
     public actual val name: String
         get() = CBLScope_Name(actual).toKString()!!
 
-    @Throws(CouchbaseLiteException::class)
-    public actual fun getCollections(): Set<Collection> {
-        val names = wrapCBLError { error ->
-            CBLScope_CollectionNames(actual, error)
-        }
-        return buildSet {
-            memScoped {
-                names?.iterator(this)?.forEach {
-                    wrapCBLError { error ->
-                        CBLScope_Collection(actual, FLValue_AsString(it), error)
-                    }?.asCollection(database)?.let(::add)
-                }
+    @Suppress("ACTUAL_ANNOTATIONS_NOT_MATCH_EXPECT") // https://youtrack.jetbrains.com/issue/KT-63047
+    //@get:Throws(CouchbaseLiteException::class)
+    public actual val collections: Set<Collection>
+        get() {
+            val names = wrapCBLError { error ->
+                CBLScope_CollectionNames(actual, error)
             }
-            FLMutableArray_Release(names)
+            return buildSet {
+                memScoped {
+                    names?.iterator(this)?.forEach {
+                        wrapCBLError { error ->
+                            CBLScope_Collection(actual, FLValue_AsString(it), error)
+                        }?.asCollection(database)?.let(::add)
+                    }
+                }
+                FLMutableArray_Release(names)
+            }
         }
-    }
 
     @Throws(CouchbaseLiteException::class)
     public actual fun getCollection(collectionName: String): Collection? {

--- a/testing-support/src/commonMain/kotlin/kotbase/BaseDbTest.kt
+++ b/testing-support/src/commonMain/kotlin/kotbase/BaseDbTest.kt
@@ -28,7 +28,7 @@ import kotlin.test.*
 import kotlin.time.Duration.Companion.seconds
 
 val Scope.collectionCount
-    get() = this.getCollections().size
+    get() = this.collections.size
 
 fun Database.createTestCollection(name: String = "coll_", scope: String = "scope_"): Collection {
     val uname = BaseTest.getUniqueName(name)


### PR DESCRIPTION
This align's Kotbase's API with how the Couchbase Lite Java SDK appears in Kotlin, allowing for more seamless adoption of Kotbase with existing Kotlin code using Couchbase Lite. It also makes the APIs more idiomatic.

**Note: this is a source-incompatible** (but binary compatible, at least on JVM) change from Kotbase 3.0.x.

Instead of:
```Kotlin
database.getIndexes()
replicator.getPendingDocumentIds()
```
now:
```Kotlin
database.indexes
replicator.pendingDocumentIds
```

Most affected APIs are still unreleased until 3.1.

This change requires working around [KT-63047](https://youtrack.jetbrains.com/issue/KT-63047), so these APIs do not appear as error throwing in native code. But the common Kotlin and JVM APIs are annotated `@get:Throws`.

It's expected the primary usage for the APIs is in common Kotlin code, but for Objective-C, the properties are hidden with `@HiddenFromObjC` and functions annotated `@Throws` are provided to allow for error handling in Swift and Objective-C.
```Swift
// in Swift
try database.indexes()
try replicator.pendingDocumentIds()
```