### PR TITLE
Dependency updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Maven Central](https://img.shields.io/maven-central/v/dev.kotbase/couchbase-lite)](
 https://central.sonatype.com/namespace/dev.kotbase)
-[![Kotlin](https://img.shields.io/badge/kotlin-2.1.0-blue.svg?logo=kotlin)](http://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/kotlin-2.1.10-blue.svg?logo=kotlin)](http://kotlinlang.org)
 [![GitHub License](https://img.shields.io/github/license/jeffdgr8/kotbase)](LICENSE)
 [![Couchbase Community](https://img.shields.io/badge/couchbase-community-ea2328?logo=couchbase&logoColor=ea2328)](
 https://www.couchbase.com/developers/community/)

--- a/couchbase-lite-ee/src/appleMain/ee/kotbase/TLSIdentity.apple.kt
+++ b/couchbase-lite-ee/src/appleMain/ee/kotbase/TLSIdentity.apple.kt
@@ -18,10 +18,10 @@ package kotbase
 import cocoapods.CouchbaseLite.CBLTLSIdentity
 import kotbase.internal.DelegatedClass
 import kotbase.ext.toByteArray
+import kotbase.ext.toKotlinInstantMillis
 import kotbase.ext.toNSData
 import kotbase.ext.wrapCBLError
 import kotlinx.datetime.Instant
-import kotlinx.datetime.toKotlinInstant
 import kotlinx.datetime.toNSDate
 import platform.Security.SecCertificateRef
 import platform.Security.SecIdentityRef
@@ -34,7 +34,7 @@ internal constructor(actual: CBLTLSIdentity) : DelegatedClass<CBLTLSIdentity>(ac
         get() = (actual.certs as List<SecCertificateRef>).map { it.toByteArray() }
 
     public actual val expiration: Instant
-        get() = actual.expiration.toKotlinInstant()
+        get() = actual.expiration.toKotlinInstantMillis()
 
     public actual companion object {
 

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/Array.apple.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/Array.apple.kt
@@ -17,10 +17,10 @@ package kotbase
 
 import cocoapods.CouchbaseLite.CBLArray
 import kotbase.ext.asNumber
+import kotbase.ext.toKotlinInstantMillis
 import kotbase.internal.DelegatedClass
 import kotlinx.cinterop.convert
 import kotlinx.datetime.Instant
-import kotlinx.datetime.toKotlinInstant
 
 public actual open class Array
 internal constructor(actual: CBLArray) : DelegatedClass<CBLArray>(actual), Iterable<Any?> {
@@ -82,7 +82,7 @@ internal constructor(actual: CBLArray) : DelegatedClass<CBLArray>(actual), Itera
 
     public actual fun getDate(index: Int): Instant? {
         checkIndex(index)
-        return actual.dateAtIndex(index.convert())?.toKotlinInstant()
+        return actual.dateAtIndex(index.convert())?.toKotlinInstantMillis()
     }
 
     public actual open fun getArray(index: Int): Array? {

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/Collection.apple.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/Collection.apple.kt
@@ -17,6 +17,7 @@ package kotbase
 
 import cocoapods.CouchbaseLite.CBLCollection
 import kotbase.ext.asDispatchQueue
+import kotbase.ext.toKotlinInstantMillis
 import kotbase.ext.wrapCBLError
 import kotbase.internal.DelegatedClass
 import kotlinx.coroutines.CoroutineDispatcher
@@ -24,7 +25,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.datetime.Instant
-import kotlinx.datetime.toKotlinInstant
 import kotlinx.datetime.toNSDate
 import kotlin.coroutines.CoroutineContext
 import kotlin.experimental.ExperimentalObjCRefinement
@@ -150,7 +150,7 @@ internal constructor(
     public actual fun getDocumentExpiration(id: String): Instant? {
         return wrapCBLError { error ->
             actual.getDocumentExpirationWithID(id, error)
-        }?.toKotlinInstant()
+        }?.toKotlinInstantMillis()
     }
 
     public actual fun addChangeListener(listener: CollectionChangeListener): ListenerToken {

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/Database.apple.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/Database.apple.kt
@@ -18,6 +18,7 @@ package kotbase
 import cocoapods.CouchbaseLite.*
 import kotbase.internal.DelegatedClass
 import kotbase.ext.asDispatchQueue
+import kotbase.ext.toKotlinInstantMillis
 import kotbase.ext.wrapCBLError
 import kotlinx.atomicfu.locks.reentrantLock
 import kotlinx.atomicfu.locks.withLock
@@ -26,7 +27,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.datetime.Instant
-import kotlinx.datetime.toKotlinInstant
 import kotlinx.datetime.toNSDate
 import kotlin.coroutines.CoroutineContext
 import kotlin.experimental.ExperimentalObjCRefinement
@@ -430,7 +430,7 @@ internal constructor(actual: CBLDatabase) : DelegatedClass<CBLDatabase>(actual),
     @Throws(CouchbaseLiteException::class)
     public actual fun getDocumentExpiration(id: String): Instant? {
         return mustBeOpen {
-            actual.getDocumentExpirationWithID(id)?.toKotlinInstant()
+            actual.getDocumentExpirationWithID(id)?.toKotlinInstantMillis()
         }
     }
 

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/Dictionary.apple.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/Dictionary.apple.kt
@@ -17,9 +17,9 @@ package kotbase
 
 import cocoapods.CouchbaseLite.CBLDictionary
 import kotbase.ext.asNumber
+import kotbase.ext.toKotlinInstantMillis
 import kotbase.internal.DelegatedClass
 import kotlinx.datetime.Instant
-import kotlinx.datetime.toKotlinInstant
 
 public actual open class Dictionary
 internal constructor(actual: CBLDictionary) : DelegatedClass<CBLDictionary>(actual), Iterable<String> {
@@ -67,7 +67,7 @@ internal constructor(actual: CBLDictionary) : DelegatedClass<CBLDictionary>(actu
         actual.blobForKey(key)?.asBlob()
 
     public actual fun getDate(key: String): Instant? =
-        actual.dateForKey(key)?.toKotlinInstant()
+        actual.dateForKey(key)?.toKotlinInstantMillis()
 
     public actual open fun getArray(key: String): Array? {
         return getInternalCollection(key)

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/Document.apple.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/Document.apple.kt
@@ -18,9 +18,9 @@ package kotbase
 import cocoapods.CouchbaseLite.CBLDocument
 import com.couchbase.lite.database
 import kotbase.ext.asNumber
+import kotbase.ext.toKotlinInstantMillis
 import kotbase.internal.DelegatedClass
 import kotlinx.datetime.Instant
-import kotlinx.datetime.toKotlinInstant
 
 public actual open class Document
 internal constructor(
@@ -90,7 +90,7 @@ internal constructor(
         actual.blobForKey(key)?.asBlob()
 
     public actual fun getDate(key: String): Instant? =
-        actual.dateForKey(key)?.toKotlinInstant()
+        actual.dateForKey(key)?.toKotlinInstantMillis()
 
     public actual open fun getArray(key: String): Array? {
         return getInternalCollection(key)

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/Result.apple.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/Result.apple.kt
@@ -18,9 +18,9 @@ package kotbase
 import cocoapods.CouchbaseLite.CBLQueryResult
 import kotbase.internal.DelegatedClass
 import kotbase.ext.asNumber
+import kotbase.ext.toKotlinInstantMillis
 import kotlinx.cinterop.convert
 import kotlinx.datetime.Instant
-import kotlinx.datetime.toKotlinInstant
 
 public actual class Result
 internal constructor(actual: CBLQueryResult) : DelegatedClass<CBLQueryResult>(actual), Iterable<String> {
@@ -75,7 +75,7 @@ internal constructor(actual: CBLQueryResult) : DelegatedClass<CBLQueryResult>(ac
 
     public actual fun getDate(index: Int): Instant? {
         assertInBounds(index)
-        return actual.dateAtIndex(index.convert())?.toKotlinInstant()
+        return actual.dateAtIndex(index.convert())?.toKotlinInstantMillis()
     }
 
     public actual fun getArray(index: Int): Array? {
@@ -123,7 +123,7 @@ internal constructor(actual: CBLQueryResult) : DelegatedClass<CBLQueryResult>(ac
         actual.blobForKey(key)?.asBlob()
 
     public actual fun getDate(key: String): Instant? =
-        actual.dateForKey(key)?.toKotlinInstant()
+        actual.dateForKey(key)?.toKotlinInstantMillis()
 
     public actual fun getArray(key: String): Array? =
         actual.arrayForKey(key)?.asArray()

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/Utils.apple.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/Utils.apple.kt
@@ -16,9 +16,9 @@
 package kotbase
 
 import cocoapods.CouchbaseLite.*
+import kotbase.ext.toKotlinInstantMillis
 import kotbase.internal.DelegatedClass
 import kotlinx.datetime.Instant
-import kotlinx.datetime.toKotlinInstant
 import kotlinx.datetime.toNSDate
 import platform.Foundation.NSDate
 import platform.Foundation.NSNull
@@ -30,7 +30,7 @@ internal fun Any.delegateIfNecessary(): Any? = when (this) {
     is CBLArray -> asArray()
     is CBLMutableDictionary -> asMutableDictionary()
     is CBLDictionary -> asDictionary()
-    is NSDate -> toKotlinInstant()
+    is NSDate -> toKotlinInstantMillis()
     is List<*> -> delegateIfNecessary()
     is Map<*, *> -> delegateIfNecessary()
     else -> this

--- a/couchbase-lite/src/appleMain/kotlin/kotbase/ext/DateExt.kt
+++ b/couchbase-lite/src/appleMain/kotlin/kotbase/ext/DateExt.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2025 Jeff Lockhart
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kotbase.ext
+
+import kotlinx.datetime.Instant
+import platform.Foundation.NSDate
+import platform.Foundation.timeIntervalSince1970
+import kotlin.math.roundToLong
+
+internal fun NSDate.toKotlinInstantMillis(): Instant {
+    val secs = timeIntervalSince1970()
+    val fullSeconds = secs.toLong()
+    val millis = (secs - fullSeconds) * MILLIS_PER_ONE
+    return Instant.fromEpochMilliseconds(fullSeconds * MILLIS_PER_ONE + millis.roundToLong())
+}

--- a/couchbase-lite/src/appleTest/kotlin/kotbase/ext/DateExtTest.kt
+++ b/couchbase-lite/src/appleTest/kotlin/kotbase/ext/DateExtTest.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 Jeff Lockhart
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package kotbase.ext
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.toNSDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DateExtTest {
+
+    @Test
+    fun testToKotlinInstantMillis() {
+        val now = Clock.System.nowMillis()
+        val nsDate = now.toNSDate()
+        val result = nsDate.toKotlinInstantMillis()
+        assertEquals(now, result)
+    }
+}

--- a/couchbase-lite/src/commonMain/kotlin/kotbase/ext/DateExt.kt
+++ b/couchbase-lite/src/commonMain/kotlin/kotbase/ext/DateExt.kt
@@ -16,6 +16,7 @@
 package kotbase.ext
 
 import kotlinx.datetime.Instant
+import kotlin.math.roundToLong
 
 /**
  * An ISO 8601 UTC string with milliseconds
@@ -23,7 +24,7 @@ import kotlinx.datetime.Instant
  * can be seconds or nanoseconds precision.
  */
 internal fun Instant.toStringMillis(): String {
-    return toString().let {
+    return roundToMillis().toString().let {
         if (it.length == 20) {
             it.dropLast(1) + ".000Z"
         } else if (it.length > 24) {
@@ -32,4 +33,12 @@ internal fun Instant.toStringMillis(): String {
             it
         }
     }
+}
+
+internal const val NANOS_PER_MILLI = 1_000_000
+internal const val MILLIS_PER_ONE = 1_000
+
+internal fun Instant.roundToMillis(): Instant {
+    val millis = nanosecondsOfSecond.toFloat() / NANOS_PER_MILLI
+    return Instant.fromEpochMilliseconds(epochSeconds * MILLIS_PER_ONE + millis.roundToLong())
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,7 @@ android.nonTransitiveRClass=true
 
 # Dokka
 org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
 
 # Publishing
 GROUP=dev.kotbase

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,14 +3,14 @@ couchbase-lite-java = "3.1.9"
 couchbase-lite-objc = "3.1.9"
 couchbase-lite-c = "3.1.9"
 dokka = "2.0.0"
-kotlinx-serialization = "1.7.3"
-mockk = "1.13.13"
+kotlinx-serialization = "1.8.0"
+mockk = "1.13.16"
 
 [plugins]
 android-library = { id = "com.android.library", version = "8.7.3" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
-kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version = "2.1.0" }
-kotlinx-binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.16.3" }
+kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version = "2.1.10" }
+kotlinx-binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.17.0" }
 vanniktech-maven-publish = { id = "com.vanniktech.maven.publish", version = "0.30.0" }
 
 [libraries]
@@ -27,9 +27,9 @@ kermit = { module = "co.touchlab:kermit", version = "2.0.5" }
 korlibs-korio = { module = "com.soywiz.korlibs.korio:korio", version = "4.0.10" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test" }
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit" }
-kotlinx-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version = "0.26.1" }
-kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.9.0" }
-kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.6.1" }
+kotlinx-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version = "0.27.0" }
+kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version = "1.10.1" }
+kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version = "0.6.2" }
 kotlinx-io = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version = "0.6.0" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }


### PR DESCRIPTION
* Kotlin 2.1.10
* kotlinx-coroutines 1.10.1
* kotlinx-binary-compatibility-validator 0.17.0
* kotlinx-serialization 1.8.0
* kotlinx-atomicfu 0.27.0
* mockk 1.13.16
* kotlinx-datetime 0.6.2
* Use millisecond precision for NSDate conversion
* Suppress Dokka v2 warning